### PR TITLE
GEOS-7560: OS X library problems

### DIFF
--- a/plugin/turbojpeg/src/main/java/it/geosolutions/imageio/plugins/turbojpeg/TurboJpegUtilities.java
+++ b/plugin/turbojpeg/src/main/java/it/geosolutions/imageio/plugins/turbojpeg/TurboJpegUtilities.java
@@ -2,7 +2,7 @@
  *    ImageI/O-Ext - OpenSource Java Image translation Library
  *    http://www.geo-solutions.it/
  *    http://java.net/projects/imageio-ext/
- *    (C) 2007 - 2012, GeoSolutions
+ *    (C) 2007 - 2016, GeoSolutions
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -71,19 +71,8 @@ public class TurboJpegUtilities {
     public static final String LIBNAME = "turbojpeg";
     
     static void load() {
-        try {            
-            System.loadLibrary(LIBNAME); // If this method is called more than once with the same library name, the second and subsequent calls are ignored.
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.info("TurboJPEG library loaded ("+LIBNAME+")");
-            }
-        } catch (java.lang.UnsatisfiedLinkError e) {
-            String os = System.getProperty("os.name").toLowerCase();
-            if (os.indexOf("mac") >= 0) {
-                System.load("/usr/lib/libturbojpeg.jnilib");
-            } else {
-                throw e;
-            }
-        }
+        // If this method is called more than once with the same library name, the second and subsequent calls are ignored.
+        System.loadLibrary(LIBNAME);
     }
 
     public static int getTurboJpegFlag(final String key) {


### PR DESCRIPTION
https://osgeo-org.atlassian.net/projects/GEOS/issues/GEOS-7560

End result is that TurboJpegUtilities#load()  is being too "smart" about finding the TJ native libraries.  It finds them, however, when TJ is used, the TJ java-bindings are not "smart" about finding the library and fails.

This PR just removes the "smarts" from TurboJpegUtilities#load() 