### PR TITLE
Fix NullPointer while detecting URLs in e.g. ExternalGraphics OnlineResource

### DIFF
--- a/library/streams/src/main/java/it/geosolutions/imageio/stream/input/spi/URLImageInputStreamSpi.java
+++ b/library/streams/src/main/java/it/geosolutions/imageio/stream/input/spi/URLImageInputStreamSpi.java
@@ -87,7 +87,7 @@ public class URLImageInputStreamSpi extends ImageInputStreamSpi {
             // URL that points to a file?
             final URL sourceURL = ((URL) input);
             final File tempFile = ImageIOUtilities.urlToFile(sourceURL);
-            if (tempFile.exists() && tempFile.isFile() && tempFile.canRead())
+            if (tempFile != null && tempFile.exists() && tempFile.isFile() && tempFile.canRead())
                 return fileStreamSPI.createInputStreamInstance(tempFile,useCache, cacheDir);
 
             // URL that does NOT points to a file, let's open up a stream

--- a/library/streams/src/test/java/it/geosolutions/imageio/stream/ImageInputStreamTest.java
+++ b/library/streams/src/test/java/it/geosolutions/imageio/stream/ImageInputStreamTest.java
@@ -18,7 +18,7 @@ package it.geosolutions.imageio.stream;
 
 /**
  * Testing custom ImageInputStream and ImageOutputStream.
- * 
+ *
  * @author Simone Giannecchini, GeoSolutions
  */
 import it.geosolutions.imageio.stream.input.FileImageInputStreamExtImpl;
@@ -47,16 +47,16 @@ import org.junit.Test;
 
 import junit.framework.Assert;
 
-public class TestImageInputStream  {
-    
+public class ImageInputStreamTest  {
+
         private final String fileName = "a.txt";
         private final String directoryName = "test-data";
-    	private final static Logger LOGGER = Logger.getLogger(TestImageInputStream.class.toString());
+        private final static Logger LOGGER = Logger.getLogger(ImageInputStreamTest.class.toString());
 
 
 
 	/**
-	 * Testing {@link 
+	 * Testing {@link
 	 */
     @Test
 	public void imageInputStreamAdapter() {
@@ -173,7 +173,7 @@ public class TestImageInputStream  {
 	// }
 	// gzipIIS.close();
 	// LOGGER.info(buf.toString());
-	//		
+	//
 	// get the original unzipped eraf
 	// final FileImageInputStreamExtImpl fileIIS = new
 	// FileImageInputStreamExtImpl(
@@ -197,7 +197,7 @@ public class TestImageInputStream  {
 
 	/**
 	 * Testing capabilities of {@link URLImageInputStreamSpi}.
-	 * 
+	 *
 	 */
 	@Test
 	public void URLImageInputStream() {
@@ -251,7 +251,7 @@ public class TestImageInputStream  {
 
 	/**
 	 * Testing capabilities of {@link FileImageInputStreamExtImpl}.
-	 * 
+	 *
 	 */
 	@Test
 	public void fileImageInputStreamExtImpl() {
@@ -275,7 +275,7 @@ public class TestImageInputStream  {
 
     /**
      * Testing capabilities of {@link StringImageInputStreamSpi}.
-     * 
+     *
      */
 	@Test
     public void stringImageInputStream() {

--- a/library/streams/src/test/java/it/geosolutions/imageio/stream/ImageOutputStreamTest.java
+++ b/library/streams/src/test/java/it/geosolutions/imageio/stream/ImageOutputStreamTest.java
@@ -39,11 +39,11 @@ import org.junit.Test;
 /**
  * @author Simone Giannecchini, GeoSolutions
  */
-public class TestImageOutputStream {
-    private final static Logger LOGGER = Logger.getLogger(TestImageOutputStream.class.toString());
+public class ImageOutputStreamTest {
+    private final static Logger LOGGER = Logger.getLogger(ImageOutputStreamTest.class.toString());
 
 
-    public TestImageOutputStream() {
+    public ImageOutputStreamTest() {
         super();
     }
     @Before
@@ -57,7 +57,7 @@ public class TestImageOutputStream {
 
     @Test
     public void test() throws FileNotFoundException, IOException {
-         
+
 
         // read test image
         RenderedImage image = JAI.create("ImageRead", TestData.file(this, "sample.jpeg"));
@@ -77,9 +77,9 @@ public class TestImageOutputStream {
                 test.flush();
                 test=null;
             }
-            
+
         }
-        
+
         // try to encode a png
         test=null;
         out=null;
@@ -90,15 +90,15 @@ public class TestImageOutputStream {
             ImageIO.write(image, "PNG", out);
             Assert.assertNotNull(null);// we should not get here!!!
         }catch(Exception e){
-            
+
         }finally{
             if(test!=null){
                 test.flush();
                 test=null;
             }
-            
+
         }
-        
+
         // try to encode a tiff
         test=null;
         out=null;
@@ -109,15 +109,15 @@ public class TestImageOutputStream {
             ImageIO.write(image, "tiff", out);
             Assert.assertNotNull(null);// we should not get here!!!
         }catch(Exception e){
-            
+
         }finally{
             if(test!=null){
                 test.flush();
                 test=null;
             }
-            
+
         }
-        
+
         // try to encode a bmp
         test=null;
         out=null;
@@ -128,15 +128,15 @@ public class TestImageOutputStream {
             ImageIO.write(image, "bmp", out);
             Assert.assertNotNull(null);// we should not get here!!!
         }catch(Exception e){
-            
+
         }finally{
             if(test!=null){
                 test.flush();
                 test=null;
             }
-            
+
         }
-        
+
         // try to encode a gif
         test=null;
         out=null;
@@ -152,10 +152,10 @@ public class TestImageOutputStream {
                 test.flush();
                 test=null;
             }
-            
-        }
-        
 
-        
+        }
+
+
+
     }
 }


### PR DESCRIPTION
added a check if `tempFile` is null, which may be the case if  `URL.getProtocol()` is not `file`

See https://github.com/geosolutions-it/imageio-ext/blob/master/library/utilities/src/main/java/it/geosolutions/imageio/utilities/ImageIOUtilities.java#L689

Fixes https://github.com/geosolutions-it/imageio-ext/issues/162