### PR TITLE
ClientStreamAbortedException logged at SEVERE level, should be at lower level

### DIFF
--- a/plugin/png/src/main/java/it/geosolutions/imageio/plugins/png/PNGWriter.java
+++ b/plugin/png/src/main/java/it/geosolutions/imageio/plugins/png/PNGWriter.java
@@ -109,7 +109,6 @@ public class PNGWriter {
             }
             pw.end();
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Failed to encode the PNG", e);
             throw e;
         } finally {
             pw.close();


### PR DESCRIPTION
Removed LOGGER.SEVERE.
Geoserver do the work of logging on Dispatcher.
