### PR TITLE
Enable running with Kakadu 7.x and lower versions of the library

### DIFF
--- a/plugin/kakadujp2/pom.xml
+++ b/plugin/kakadujp2/pom.xml
@@ -39,7 +39,24 @@
     	<groupId>it.geosolutions.imageio-ext</groupId>
   	<artifactId>imageio-ext-kakadujni</artifactId>
     </dependency>
-  </dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito2</artifactId>
+        <version>2.0.2</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>2.0.2</version>
+        <scope>test</scope>
+    </dependency>
+   </dependencies>
   <name>Direct Kakadu Jpeg2000 Plugin</name>
 </project>
 

--- a/plugin/kakadujp2/src/main/java/it/geosolutions/imageio/plugins/jp2k/JP2KKakaduImageWriter.java
+++ b/plugin/kakadujp2/src/main/java/it/geosolutions/imageio/plugins/jp2k/JP2KKakaduImageWriter.java
@@ -1117,7 +1117,15 @@ public class JP2KKakaduImageWriter extends ImageWriter {
         params.Parse_string("Clayers=" + qualityLayers);
         
         if (dataType == DataBuffer.TYPE_SHORT || dataType == DataBuffer.TYPE_USHORT ){
-            params.Parse_string("Qstep=0.0000152588");
+            // this setting fails with v7.x. Omiting it shouldn't be a problem though,
+            // according to <http://kakadusoftware.com/version-notes/version-7-10> :
+            // f. There are now fewer occasions when kdu_compress will warn about
+            // potentially insufficient quantization precision if Qstep is not explicitly
+            // specified, since the default policy now automatically configures Qstep to
+            // take into account the channel bit-depth of the source material.
+            if(KakaduUtilities.getKakaduJniMajorVersion() < 7) {
+                params.Parse_string("Qstep=0.0000152588");
+            }
         }
 
         if (qGuard > 0) {

--- a/plugin/kakadujp2/src/main/java/it/geosolutions/imageio/plugins/jp2k/JP2KKakaduImageWriter.java
+++ b/plugin/kakadujp2/src/main/java/it/geosolutions/imageio/plugins/jp2k/JP2KKakaduImageWriter.java
@@ -1422,10 +1422,9 @@ public class JP2KKakaduImageWriter extends ImageWriter {
 
             // Setting channels
             Jp2_channels channels = target.Access_channels();
-            channels.Init(3);
-            channels.Set_colour_mapping(0, 0, 0);
-            channels.Set_colour_mapping(1, 0, 1);
-            channels.Set_colour_mapping(2, 0, 2);
+            // Delegate to this utility method to handle JNI lib version signature
+            // differences in Jp2_channels..Set_colour_mapping()
+            KakaduUtilities.initializeRGBChannels(channels);
         }
 
         // Finish the initialization by writing the header

--- a/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/JP2KKakaduWriteTest.java
+++ b/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/JP2KKakaduWriteTest.java
@@ -326,9 +326,6 @@ public class JP2KKakaduWriteTest {
     }
 
     public @Test void testReducedMemory() throws IOException {
-        Assume.assumeTrue("REVISIT: This test fails with this Kakadu version:" + majorVersion + ": test skipped",
-                majorVersion < 7);
-
         System.setProperty(JP2KKakaduImageWriter.MAX_BUFFER_SIZE_KEY, "64K");
         final ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_GRAY);
         ColorModel cm = new ComponentColorModel(cs, new int[] { 16 }, false,
@@ -387,9 +384,6 @@ public class JP2KKakaduWriteTest {
     }
 
     public @Test void test12BitGray() throws IOException {
-        Assume.assumeTrue("REVISIT: This test fails with this Kakadu version:" + majorVersion + ": test skipped",
-                majorVersion < 7);
-
         final ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_GRAY);
         ColorModel cm = new ComponentColorModel(cs, new int[] { 12 }, false,
                 false, Transparency.OPAQUE, DataBuffer.TYPE_USHORT);
@@ -420,9 +414,6 @@ public class JP2KKakaduWriteTest {
     }
 
     public @Test void test16BitGray() throws IOException {
-        Assume.assumeTrue("REVISIT: This test fails with this Kakadu version:" + majorVersion + ": test skipped",
-                majorVersion < 7);
-
         final ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_GRAY);
         ColorModel cm = new ComponentColorModel(cs, new int[] { 16 }, false,
                 false, Transparency.OPAQUE, DataBuffer.TYPE_USHORT);

--- a/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/JP2KKakaduWriteTest.java
+++ b/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/JP2KKakaduWriteTest.java
@@ -51,32 +51,31 @@ import javax.media.jai.JAI;
 import javax.media.jai.ParameterBlockJAI;
 import javax.media.jai.RenderedOp;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 import kdu_jni.KduException;
 
 import com.sun.imageio.plugins.bmp.BMPImageReaderSpi;
 
-public class JP2KKakaduWriteTest extends TestCase {
+public class JP2KKakaduWriteTest {
 
     /** The LOGGER for this class. */
     private static final Logger LOGGER = Logger
             .getLogger("it.geosolutions.imageio.plugins.jp2k");
 
-    public JP2KKakaduWriteTest(String name) {
-        super(name);
-    }
-    
     private static boolean isKakaduAvailable;
-    
+    private static int majorVersion;
+
     private static int writeOperations = 0;
 
     private final static double lossLessQuality = 1;
 
     private final static double lossyQuality = 0.125;
 
-    private final static String testPath;
+    private static String testPath;
 
     private final static String FILE_SEPARATOR = System
             .getProperty("file.separator");
@@ -106,13 +105,15 @@ public class JP2KKakaduWriteTest extends TestCase {
         }
     }
 
-    static {
-        try{
-            isKakaduAvailable = KakaduUtilities.isKakaduAvailable();
-        }
-        catch (UnsatisfiedLinkError ule){
-            isKakaduAvailable = false;
-        }
+    private final static String[] files = new String[] { };
+
+//    private final static String inputFileName = testPath;
+
+    private static String outputFileName;
+
+    public static @BeforeClass void beforeClass(){
+        isKakaduAvailable = KakaduUtilities.isKakaduAvailable();
+        majorVersion = KakaduUtilities.getKakaduJniMajorVersion();
         String path = System.getProperty("data.path");
         if (path != null && path.length() > 1) {
             path = path.replace("\\", "/");
@@ -121,25 +122,18 @@ public class JP2KKakaduWriteTest extends TestCase {
                 testPath = path;
             else
                 testPath = path + "/";
-        } else
+        } else {
             testPath = System.getProperty("java.io.tmpdir");
-       
-    }
-
-    private final static String[] files = new String[] { };
-
-//    private final static String inputFileName = testPath;
-
-    private final static String outputFileName = testPath + FILE_SEPARATOR
-            + "out";
-
-    public void testKakaduWriter() throws KduException, FileNotFoundException,
-            IOException {
-        if(!isKakaduAvailable){
-            LOGGER
-            .warning("Kakadu libs not found: test are skipped ");
-            return;
         }
+        outputFileName = testPath + FILE_SEPARATOR + "out";    
+    }
+    
+    public @Before void before() {
+        Assume.assumeTrue("Kakadu libs not found: tests are skipped", isKakaduAvailable);
+    }
+    
+    public @Test void testKakaduWriter() throws KduException, FileNotFoundException,
+            IOException {
         for (String fileName : files) {
 //            final String filePath = inputFileName + fileName;
 //            final File file = new File(filePath);
@@ -212,13 +206,8 @@ public class JP2KKakaduWriteTest extends TestCase {
         }
     }
 
-    public void testKakaduWriterParam() throws KduException,
+    public @Test void testKakaduWriterParam() throws KduException,
             FileNotFoundException, IOException {
-        if(!isKakaduAvailable){
-            LOGGER
-            .warning("Kakadu libs not found: test are skipped ");
-            return;
-        }
         if (files.length==0) {
             LOGGER.warning("No files have been specified. This test will be skipped");
             return;
@@ -333,43 +322,13 @@ public class JP2KKakaduWriteTest extends TestCase {
     }
 
     public static void main(java.lang.String[] args) {
-        junit.textui.TestRunner.run(suite());
         LOGGER.info(writeOperations + " write operations performed");
     }
 
-    public static Test suite() {
+    public @Test void testReducedMemory() throws IOException {
+        Assume.assumeTrue("REVISIT: This test fails with this Kakadu version:" + majorVersion + ": test skipped",
+                majorVersion < 7);
 
-
-        TestSuite suite = new TestSuite();
-
-        suite.addTest(new JP2KKakaduWriteTest("testKakaduWriter"));
-
-        suite.addTest(new JP2KKakaduWriteTest("testKakaduWriterParam"));
-
-        suite.addTest(new JP2KKakaduWriteTest("testRGB"));
-
-        suite.addTest(new JP2KKakaduWriteTest("test8BitGray"));
-
-        suite.addTest(new JP2KKakaduWriteTest("test12BitGray"));
-
-        suite.addTest(new JP2KKakaduWriteTest("test16BitGray"));
-
-        suite.addTest(new JP2KKakaduWriteTest("test24BitGray"));
-
-        suite.addTest(new JP2KKakaduWriteTest("testPalettedRGB"));
-
-        suite.addTest(new JP2KKakaduWriteTest("testReducedMemory"));
-        suite.addTest(new JP2KKakaduWriteTest("testOutputStream"));
-
-        return suite;
-    }
-
-    public static void testReducedMemory() throws IOException {
-        if(!isKakaduAvailable){
-            LOGGER
-            .warning("Kakadu libs not found: test are skipped ");
-            return;
-        }
         System.setProperty(JP2KKakaduImageWriter.MAX_BUFFER_SIZE_KEY, "64K");
         final ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_GRAY);
         ColorModel cm = new ComponentColorModel(cs, new int[] { 16 }, false,
@@ -389,7 +348,7 @@ public class JP2KKakaduWriteTest extends TestCase {
         DataBuffer imageBuffer = new DataBufferUShort(bufferValues, bufferSize);
         BufferedImage bi = new BufferedImage(cm, Raster.createWritableRaster(
                 sm, imageBuffer, null), false, null);
-
+        
         write(outputFileName + "_RM", bi, true, lossLessQuality);
         write(outputFileName + "_RM", bi, false, lossLessQuality);
         write(outputFileName + "_RM", bi, true, lossyQuality);
@@ -397,12 +356,7 @@ public class JP2KKakaduWriteTest extends TestCase {
         LOGGER.info(writeOperations + " write operations performed");
     }
 
-    public static void test8BitGray() throws IOException {
-        if(!isKakaduAvailable){
-            LOGGER
-            .warning("Kakadu libs not found: test are skipped ");
-            return;
-        }
+    public @Test void test8BitGray() throws IOException {
         final ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_GRAY);
         ColorModel cm = new ComponentColorModel(cs, new int[] { 8 }, false,
                 false, Transparency.OPAQUE, DataBuffer.TYPE_BYTE);
@@ -432,12 +386,10 @@ public class JP2KKakaduWriteTest extends TestCase {
         LOGGER.info(writeOperations + " write operations performed");
     }
 
-    public static void test12BitGray() throws IOException {
-        if(!isKakaduAvailable){
-            LOGGER
-            .warning("Kakadu libs not found: test are skipped ");
-            return;
-        }
+    public @Test void test12BitGray() throws IOException {
+        Assume.assumeTrue("REVISIT: This test fails with this Kakadu version:" + majorVersion + ": test skipped",
+                majorVersion < 7);
+
         final ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_GRAY);
         ColorModel cm = new ComponentColorModel(cs, new int[] { 12 }, false,
                 false, Transparency.OPAQUE, DataBuffer.TYPE_USHORT);
@@ -467,12 +419,10 @@ public class JP2KKakaduWriteTest extends TestCase {
         LOGGER.info(writeOperations + " write operations performed");
     }
 
-    public static void test16BitGray() throws IOException {
-        if(!isKakaduAvailable){
-            LOGGER
-            .warning("Kakadu libs not found: test are skipped ");
-            return;
-        }
+    public @Test void test16BitGray() throws IOException {
+        Assume.assumeTrue("REVISIT: This test fails with this Kakadu version:" + majorVersion + ": test skipped",
+                majorVersion < 7);
+
         final ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_GRAY);
         ColorModel cm = new ComponentColorModel(cs, new int[] { 16 }, false,
                 false, Transparency.OPAQUE, DataBuffer.TYPE_USHORT);
@@ -508,12 +458,7 @@ public class JP2KKakaduWriteTest extends TestCase {
         LOGGER.info(writeOperations + " write operations performed");
     }
 
-    public static void test24BitGray() throws IOException {
-        if(!isKakaduAvailable){
-            LOGGER
-            .warning("Kakadu libs not found: test are skipped ");
-            return;
-        }
+    public @Test void test24BitGray() throws IOException {
         final ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_GRAY);
         ColorModel cm = new ComponentColorModel(cs, new int[] { 24 }, false,
                 false, Transparency.OPAQUE, DataBuffer.TYPE_INT);
@@ -548,13 +493,7 @@ public class JP2KKakaduWriteTest extends TestCase {
         LOGGER.info(writeOperations + " write operations performed");
     }
 
-    public void testOutputStream() throws IOException {
-        
-        if(!isKakaduAvailable){
-            LOGGER
-            .warning("Kakadu libs not found: test are skipped ");
-            return;
-        }
+    public @Test void testOutputStream() throws IOException {
         final File outFile = File.createTempFile("stream", "temp");
         final FileImageOutputStream stream = new FileImageOutputStream (outFile);
         stream.writeBytes("This is an Image Header written before the j2c raw codestream");
@@ -575,12 +514,8 @@ public class JP2KKakaduWriteTest extends TestCase {
         writer.dispose();
         LOGGER.info(writeOperations + " write operations performed");
     }
-    public void testRGB() throws IOException {
-        if(!isKakaduAvailable){
-            LOGGER
-            .warning("Kakadu libs not found: test are skipped ");
-            return;
-        }
+    
+    public @Test void testRGB() throws IOException {
         final File file = TestData.file(this, "RGB24.bmp");
         final ImageReader reader = new BMPImageReaderSpi()
                 .createReaderInstance();
@@ -597,18 +532,13 @@ public class JP2KKakaduWriteTest extends TestCase {
         LOGGER.info(writeOperations + " write operations performed");
     }
 
-    public void testPalettedRGB() throws IOException {
-        if(!isKakaduAvailable){
-            LOGGER
-            .warning("Kakadu libs not found: test are skipped ");
-            return;
-        }
-//        BufferedImage bi = ImageIO.read(TestData.file(this, "paletted.tif"));
-//        write(outputFileName + "_RGB8", bi, true, lossLessQuality);
-//        write(outputFileName + "_RGB8", bi, false, lossLessQuality);
-//        write(outputFileName + "_JAI_RGB8", bi, true, lossLessQuality, true);
-//        write(outputFileName + "_JAI_RGB8", bi, false, lossLessQuality, true);
-//        LOGGER.info(writeOperations + " write operations performed");
+    public @Test void testPalettedRGB() throws IOException {
+        BufferedImage bi = ImageIO.read(TestData.file(this, "paletted.tif"));
+        write(outputFileName + "_RGB8", bi, true, lossLessQuality);
+        write(outputFileName + "_RGB8", bi, false, lossLessQuality);
+        write(outputFileName + "_JAI_RGB8", bi, true, lossLessQuality, true);
+        write(outputFileName + "_JAI_RGB8", bi, false, lossLessQuality, true);
+        LOGGER.info(writeOperations + " write operations performed");
     }
 
     private static void write(String file, final RenderedImage bi,

--- a/plugin/kakadujp2/src/test/java/it/geosolutions/util/KakaduUtilitiesTest.java
+++ b/plugin/kakadujp2/src/test/java/it/geosolutions/util/KakaduUtilitiesTest.java
@@ -1,0 +1,90 @@
+package it.geosolutions.util;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+import jdk.nashorn.internal.ir.annotations.Ignore;
+import kdu_jni.Jp2_channels;
+
+@RunWith(PowerMockRunner.class)
+//delegate to standard runner so assumeTrue works
+@PowerMockRunnerDelegate(BlockJUnit4ClassRunner.class)
+//suppress System.loadLibrary in static initialization of these classes
+@SuppressStaticInitializationFor({ "kdu_jni.Kdu_global", "kdu_jni.Jp2_channels" })
+public class KakaduUtilitiesTest {
+
+    private static int JNI_VERSION;
+
+    public static @BeforeClass void beforeClass() throws Exception {
+        JNI_VERSION = KakaduUtilities.getKakaduJniMajorVersion();
+    }
+
+    private static class SetColorMappingCapturer implements Answer<Object> {
+
+        List<List<Object>> invocationArguments = new ArrayList<>();
+
+        public @Override Object answer(InvocationOnMock invocation) {
+            Method method = invocation.getMethod();
+            if ("Set_colour_mapping".equals(method.getName())) {
+                Object[] arguments = invocation.getArguments();
+                invocationArguments.add(asList(arguments));
+            }
+            return null;
+        }
+    };
+
+    private SetColorMappingCapturer colorMappingCapturer;
+    private Jp2_channels channels;
+
+    public @Before void before() {
+        colorMappingCapturer = new SetColorMappingCapturer();
+        channels = PowerMockito.mock(Jp2_channels.class, colorMappingCapturer);
+    }
+
+    public @Test void testInitializeRGBChannels_KduPreV7() throws Exception {
+        assumeTrue(format("JNI version=%d, expected < 7, ignoring", JNI_VERSION), JNI_VERSION < 7);
+
+        KakaduUtilities.initializeRGBChannels(channels);
+
+        verify(channels).Init(eq(3));
+        List<List<Object>> args = colorMappingCapturer.invocationArguments;
+        assertEquals(3, args.size());
+
+        List<List<Object>> expectedCallsAndArgs = asList(asList(0, 0, 0), asList(1, 0, 1), asList(2, 0, 2));
+        assertEquals(expectedCallsAndArgs, args);
+    }
+
+    public @Ignore @Test void testInitializeRGBChannels_KduV7Plus() throws Exception {
+        assumeTrue(format("JNI version=%d, expected >= 7, ignoring", JNI_VERSION), JNI_VERSION >= 7);
+
+        KakaduUtilities.initializeRGBChannels(channels);
+
+        verify(channels).Init(eq(3));
+        List<List<Object>> args = colorMappingCapturer.invocationArguments;
+        assertEquals(3, args.size());
+
+        List<List<Object>> expectedCallsAndArgs = asList(asList(0, 0, 0, 0, 0), asList(1, 0, 1, 0, 0),
+                asList(2, 0, 2, 0, 0));
+        assertEquals(expectedCallsAndArgs, args);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.12</version>
       </dependency>
       <dependency>
        <groupId>it.geosolutions.imageio-ext</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -403,6 +403,13 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.12</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>2.28.2</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
        <groupId>it.geosolutions.imageio-ext</groupId>


### PR DESCRIPTION
Fixes #206 

Due to a binary incompatibility in `kdu_jni.jar` between
versions 7.x and lower, `JP2KKakaduImageWriter` delegates
to `KakaduUtilities.initializeRGBChannels()`
when it gets an `IndexColorModel` to set up the `Jp2_channels`,
which uses reflection to invoke `Jp2_channels.Set_colour_mapping()`
with the correct number of arguments depending on the
Kakadu JNI library version.

Add utility methods to `KakaduUtilities` to return the
version strings returned by both the JNI and the native
libraries and issue a warning if there's a version mismatch
when loading the native library.
