### PR TITLE
Bug fixes for using TiffImageWriter.replacePixels using bigTIFF

### DIFF
--- a/plugin/tiff/src/main/java/it/geosolutions/imageioimpl/plugins/tiff/TIFFIFD.java
+++ b/plugin/tiff/src/main/java/it/geosolutions/imageioimpl/plugins/tiff/TIFFIFD.java
@@ -470,7 +470,7 @@ public class TIFFIFD extends TIFFDirectory {
                 TIFFIFD subIFD = new TIFFIFD(tagSets);
 
                 // XXX Use same ignore policy for sub-IFD fields?
-                subIFD.initialize(stream, ignoreUnknownFields);
+                subIFD.initialize(stream, ignoreUnknownFields, isBTIFF);
                 obj = subIFD;
                 stream.reset();
             }

--- a/plugin/tiff/src/main/java/it/geosolutions/imageioimpl/plugins/tiff/TIFFImageWriter.java
+++ b/plugin/tiff/src/main/java/it/geosolutions/imageioimpl/plugins/tiff/TIFFImageWriter.java
@@ -3390,7 +3390,7 @@ public class TIFFImageWriter extends ImageWriter {
         TIFFIFD rootIFD = new TIFFIFD(tagSets);
         // XXX Ignore unknown fields in metadata presumably because
         // any fields needed to write pixels would be known?
-        rootIFD.initialize(stream, true);
+        rootIFD.initialize(stream, true, isBtiff);
         stream.reset();
 
         return rootIFD;
@@ -3455,8 +3455,7 @@ public class TIFFImageWriter extends ImageWriter {
             }
 
             // Get the image dimensions.
-            f =
-                replacePixelsIFD.getTIFFField(BaselineTIFFTagSet.TAG_IMAGE_WIDTH);
+            f = replacePixelsIFD.getTIFFField(BaselineTIFFTagSet.TAG_IMAGE_WIDTH);
             if(f == null) {
                 throw new IIOException("Cannot read ImageWidth field.");
             }
@@ -3905,12 +3904,18 @@ public class TIFFImageWriter extends ImageWriter {
                             // Update Strip/TileOffsets and
                             // Strip/TileByteCounts fields.
                             stream.mark();
-                            stream.seek(replacePixelsOffsetsPosition +
-                                        4*tileIndex);
-                            stream.writeInt((int)nextSpace);
-                            stream.seek(replacePixelsByteCountsPosition +
-                                        4*tileIndex);
-                            stream.writeInt(numBytes);
+
+                            if (isBtiff) {
+                                stream.seek(replacePixelsOffsetsPosition + 8 * tileIndex);
+                                stream.writeLong(nextSpace);
+                                stream.seek(replacePixelsByteCountsPosition + 8 * tileIndex);
+                                stream.writeLong(numBytes);
+                            } else {
+                                stream.seek(replacePixelsOffsetsPosition + 4 * tileIndex);
+                                stream.writeInt((int)nextSpace);
+                                stream.seek(replacePixelsByteCountsPosition + 4 * tileIndex);
+                                stream.writeInt(numBytes);
+                            }
                             stream.reset();
 
                             // Increment location of next available space.


### PR DESCRIPTION
This is a bug fix for issue #217 