### PR TITLE
Issue-225: COG reading access object

### DIFF
--- a/library/geocore/src/main/java/it/geosolutions/imageio/core/ReadingAccessObject.java
+++ b/library/geocore/src/main/java/it/geosolutions/imageio/core/ReadingAccessObject.java
@@ -1,0 +1,63 @@
+/*
+ *    ImageI/O-Ext - OpenSource Java Image translation Library
+ *    http://www.geo-solutions.it/
+ *    https://github.com/geosolutions-it/imageio-ext
+ *    (C) 2020, GeoSolutions
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    either version 3 of the License, or (at your option) any later version.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package it.geosolutions.imageio.core;
+
+import javax.imageio.spi.ImageInputStreamSpi;
+import javax.imageio.spi.ImageReaderSpi;
+
+/**
+ * An object containing elementary objects for a reading access on a source:
+ * a provided SPI to get an ImageReader as well as a provided SPI to get
+ * an ImageInputStream on top of that source.
+ */
+public class ReadingAccessObject {
+
+    private ImageReaderSpi readerSpi;
+    private ImageInputStreamSpi streamSpi;
+    private String source;
+
+    public ImageInputStreamSpi getStreamSpi() {
+        return streamSpi;
+    }
+
+    public void setStreamSpi(ImageInputStreamSpi streamSpi) {
+        this.streamSpi = streamSpi;
+    }
+
+    public ImageReaderSpi getReaderSpi() {
+        return readerSpi;
+    }
+
+    public void setReaderSpi(ImageReaderSpi readerSpi) {
+        this.readerSpi = readerSpi;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public ReadingAccessObject(
+            String source, ImageReaderSpi readerSpi, ImageInputStreamSpi streamSpi) {
+        this.readerSpi = readerSpi;
+        this.streamSpi = streamSpi;
+        this.source = source;
+    }
+}

--- a/plugin/cog/cog-reader/src/main/java/it/geosolutions/imageioimpl/plugins/cog/CogReadingAccessObject.java
+++ b/plugin/cog/cog-reader/src/main/java/it/geosolutions/imageioimpl/plugins/cog/CogReadingAccessObject.java
@@ -1,0 +1,97 @@
+/*
+ *    ImageI/O-Ext - OpenSource Java Image translation Library
+ *    http://www.geo-solutions.it/
+ *    https://github.com/geosolutions-it/imageio-ext
+ *    (C) 2020, GeoSolutions
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    either version 3 of the License, or (at your option) any later version.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package it.geosolutions.imageioimpl.plugins.cog;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.net.URI;
+import javax.imageio.spi.ImageInputStreamSpi;
+import javax.imageio.spi.ImageReaderSpi;
+import javax.imageio.stream.ImageInputStream;
+import it.geosolutions.imageio.core.ReadingAccessObject;
+import it.geosolutions.imageio.plugins.cog.CogImageReadParam;
+
+/**
+ * A @{@link ReadingAccessObject}  subclass containing additional
+ * elements for the COG Implementation
+ */
+public class CogReadingAccessObject extends ReadingAccessObject {
+
+    /** A cogUri version of the source */
+    private CogUri cogUri;
+
+    /** The full classname of the RangeReader implementation */
+    private String rangeReaderClassname;
+
+    public CogReadingAccessObject(
+            CogUri cogUri,
+            ImageReaderSpi readerSpi,
+            ImageInputStreamSpi streamSpi,
+            String rangeReader) {
+        super(cogUri.getUri().toString(), readerSpi, streamSpi);
+        this.cogUri = cogUri;
+        this.rangeReaderClassname = rangeReader;
+    }
+
+    public String getRangeReaderClassname() {
+        return rangeReaderClassname;
+    }
+
+    public CogUri getCogUri() {
+        return cogUri;
+    }
+
+    /**
+     * Get an initialized COG stream: The Header will be read before
+     * returning the stream back to the caller.
+     */
+    public ImageInputStream getInitializedCogInputStream() throws IOException {
+        CogUri uri = getCogUri();
+        CogImageInputStream inStream =
+                (CogImageInputStream)
+                        ((CogImageInputStreamSpi) getStreamSpi())
+                                .createInputStreamInstance(uri, uri.isUseCache(), null);
+        RangeReader rangeReader = createRangeReaderInstance(rangeReaderClassname, uri.getUri(), CogImageReadParam.DEFAULT_HEADER_LENGTH);
+        inStream.init(rangeReader);
+        return inStream;
+    }
+
+    /**
+     * Instantiate a new RangeReader based on the specified className implementation,
+     * on top of the given URI, using the specified headerLength
+     *
+     * @param className the complete className of the required RangeReader implementation
+     * @param uri the source URI
+     * @param headerLength the headerLength
+     * @return a RangeReader instance
+     */
+    public static RangeReader createRangeReaderInstance(String className, URI uri, int headerLength) {
+        RangeReader rangeReader = null;
+        if (className != null) {
+            try {
+                final Class<?> clazz = Class.forName(className);
+                Constructor constructor = clazz.getConstructor(new Class[] {URI.class, int.class});
+                rangeReader =
+                        (RangeReader)
+                                constructor.newInstance(uri, headerLength);
+            } catch (Exception e) {
+                rangeReader = null;
+            }
+        }
+        return rangeReader;
+    }
+}


### PR DESCRIPTION
COG (Cloud Optimized GeoTIFF) data requires a set of I/O objects to be instantiated to perform reading access.
i.e. a CogUri, an ImageInputStreamSpi to create a stream on top of that CogUri, an ImageReaderSpi to create a reader for that CogUri, a RangeReader definition to do future ranges-read operations on the stream.

In addition, higher level reader will need all the above references in a single place in order to properly do I/O on an URI referring a COG dataset.

It would be useful to have a kind of (COG) ReadingAccessObject storing all of these type of info on a single place, as a bean.

Suggestions for better names are welcome.
Maybe ReadProviderBean? ReadingContextBean?