### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: java
 jdk:
   - oraclejdk8
 script:
-  - mvn -U clean install -Dall -Djava.awt.headless=true -DskipTests=false
+  - mvn -T 1C -U clean install -Dall -Djava.awt.headless=true -DskipTests=false
 notifications:
   email: false
   on_failure: never

--- a/library/geocore/pom.xml
+++ b/library/geocore/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>it.geosolutions.imageio-ext</groupId>
@@ -23,11 +22,7 @@
       <version>2.3.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>it.geosolutions.imageio-ext</groupId>
-      <artifactId>imageio-ext-utilities</artifactId>
-      <version>${project.version}</version>
-    </dependency>  
+      
     <dependency>
       <groupId>it.geosolutions.imageio-ext</groupId>
       <artifactId>imageio-ext-streams</artifactId>
@@ -44,16 +39,7 @@
       <artifactId>jaxb-api</artifactId>
       <version>2.4.0-b180830.0359</version>
     </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.4.0-b180830.0438</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>javax.activation-api</artifactId>
-      <version>1.2.0</version>
-    </dependency>
+    
+    
   </dependencies>
 </project>

--- a/library/netcdf-core/pom.xml
+++ b/library/netcdf-core/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>it.geosolutions.imageio-ext</groupId> 
@@ -12,13 +11,15 @@
   <packaging>jar</packaging>
   <version>1.3-SNAPSHOT</version>
    
-   <!--repositories>
+   
+<!--repositories>
     <repository>
       <id>ulisse</id>
       <name>Ulisse libraries repository</name>
       <url>http://ulisse.pin.unifi.it:8080/archiva/repository/ext.public.rel/</url>
     </repository>
   </repositories-->
+
    
    <dependencies>
     <dependency>
@@ -26,41 +27,20 @@
       <artifactId>imageio-ext-streams</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-        <groupId>it.geosolutions.imageio-ext</groupId>
-        <artifactId>imageio-ext-test-data</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
+    
     <dependency>
       <groupId>it.geosolutions.imageio-ext</groupId>
       <artifactId>imageio-ext-geocore</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>java3d</groupId>
-      <artifactId>vecmath</artifactId>
-      <version>1.3.1</version>
-      <scope>test</scope>
-    </dependency>
+    
     <dependency>
       <groupId>essi-unidata</groupId>
       <artifactId>netcdf-java</artifactId>
       <version>4.0.41</version>
     </dependency>
-     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.5.6</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-    <!-- required to read files remotely over HTTP -->
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
-      <scope>runtime</scope>
-    </dependency>
+     
+    
        
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-  <project xmlns="http://maven.apache.org/POM/4.0.0"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                               http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                                http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <!--                    -->
+  
+<!--                    -->
+
   <!--    PROPERTIES      -->
   <!--                    -->
   <properties>
@@ -537,7 +535,7 @@
           <forkMode>once</forkMode>
           <argLine>-Xmx${test.maxHeapSize} -enableassertions -Dtest.extensive=${extensive.tests} -Dtest.interactive=${interactive.tests} -Djava.awt.headless=${java.awt.headless}  -XX:+IgnoreUnrecognizedVMOptions --illegal-access=debug</argLine>
          </configuration>
-      </plugin>
+      <configuration><parallel>all</parallel></configuration></plugin>
       
       <plugin>
           <inherited>true</inherited>


### PR DESCRIPTION

[Parallel builds in Maven 3](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3) Maven 3.x has the capability to perform parallel builds.

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
imageio-ext
imageio-ext-library
imageio-ext-utilities
{groupId='junit', artifactId='junit', version='4.12', scope='test'}
imageio-ext-test-data
{groupId='javax.media', artifactId='jai_core', version='1.1.3', scope='compile'}
{groupId='javax.media', artifactId='jai_codec', version='1.1.3', scope='compile'}
{groupId='javax.media', artifactId='jai_imageio', version='1.1', scope='compile'}
{groupId='junit', artifactId='junit', version='4.12', scope='test'}
imageio-ext-streams
{groupId='javax.media', artifactId='jai_codec', version='1.1.3', scope='compile'}
imageio-ext-geocore
{groupId='it.geosolutions.imageio-ext', artifactId='imageio-ext-utilities', version='1.3-SNAPSHOT', scope='compile'}
{groupId='org.glassfish.jaxb', artifactId='jaxb-runtime', version='2.4.0-b180830.0438', scope='runtime'}
{groupId='javax.activation', artifactId='javax.activation-api', version='1.2.0', scope='compile'}
{groupId='javax.media', artifactId='jai_core', version='1.1.3', scope='compile'}
{groupId='javax.media', artifactId='jai_codec', version='1.1.3', scope='compile'}
{groupId='javax.media', artifactId='jai_imageio', version='1.1', scope='compile'}
imageio-ext-gdalframework
{groupId='javax.media', artifactId='jai_codec', version='1.1.3', scope='compile'}
imageio-ext-imagereadmt
{groupId='javax.media', artifactId='jai_codec', version='1.1.3', scope='compile'}
imageio-ext-netcdf-core
{groupId='it.geosolutions.imageio-ext', artifactId='imageio-ext-test-data', version='1.3-SNAPSHOT', scope='test'}
{groupId='java3d', artifactId='vecmath', version='1.3.1', scope='test'}
{groupId='org.slf4j', artifactId='slf4j-log4j12', version='1.5.6', scope='runtime'}
{groupId='commons-httpclient', artifactId='commons-httpclient', version='3.1', scope='runtime'}
{groupId='javax.media', artifactId='jai_core', version='1.1.3', scope='compile'}
{groupId='javax.media', artifactId='jai_codec', version='1.1.3', scope='compile'}
{groupId='javax.media', artifactId='jai_imageio', version='1.1', scope='compile'}
{groupId='junit', artifactId='junit', version='4.12', scope='test'}
turbojpeg-wrapper
imageio-ext-plugin


According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
