### PR TITLE
gdal.version property defined twice in root pm.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
     <extensive.tests>false</extensive.tests>
     <interactive.tests>false</interactive.tests>
     <test.maxHeapSize>512M</test.maxHeapSize>
-    <gdal.version>1.9.2</gdal.version>
     <kakadu.version>5.2.6</kakadu.version>
     <java.awt.headless>true</java.awt.headless>
     <gdal.version>2.2.0</gdal.version>  


### PR DESCRIPTION
Both version 1.9.2 and 2.2.0 were listed.

Actually there may be a mistake a bit later on in dependencyManagement section:
```
      <dependency>
       <groupId>it.geosolutions.imageio-ext</groupId>
       <artifactId>imageio-ext-gdal-bindings</artifactId>
       <version>${gdal.version}</version>
     </dependency>
```

Should be the one included in the project, which has a transitive dependency on the official gdal bindings:
```
      <dependency>
       <groupId>it.geosolutions.imageio-ext</groupId>
       <artifactId>imageio-ext-gdalframework</artifactId>
       <version>${project.version}</version>
     </dependency>
```

Assume that is dead code