### PR TITLE
Update to gdal 3.2.0 bindings

### DIFF
--- a/library/gdalframework/pom.xml
+++ b/library/gdalframework/pom.xml
@@ -18,9 +18,8 @@
       <scope>test</scope>
     </dependency>
       <dependency>
-          <groupId>org.gdal</groupId>
-          <artifactId>gdal</artifactId>
-          <version>${gdal.version}</version>
+        <groupId>org.gdal</groupId>
+        <artifactId>gdal</artifactId>
       </dependency>
       <dependency>
       <groupId>it.geosolutions.imageio-ext</groupId>
@@ -43,6 +42,7 @@
   <plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-jar-plugin</artifactId>
+	  <version>3.2.2</version>
 	<executions>
 	  <execution>
 	    <goals>

--- a/library/gdalframework/src/main/java/it/geosolutions/imageio/gdalframework/GDALUtilities.java
+++ b/library/gdalframework/src/main/java/it/geosolutions/imageio/gdalframework/GDALUtilities.java
@@ -628,33 +628,33 @@ public final class GDALUtilities {
             gdal.AllRegister(); //will throw if library not already present
             if (gdal.GetDriverCount() > 0){
                 //at least one driver was recognized
-                LOGGER.log(Level.FINE,"ensureGDALLibraryLoaded: library is already loaded.");
+                LOGGER.log(Level.FINE,"ensureGDALLibraryLoaded: confirmed library is loaded and available.");
                 return;
             }
         } catch (Throwable ignore) {
             // Just checking if load library has already been called
             // nothing to do - will fix next by trying to load library
         }
+        // GDAL version >= 2.3.0
         try {
-            // GDAL version >= 2.3.0
             System.loadLibrary("gdalalljni");
             LOGGER.log(Level.FINE,"ensureGDALLibraryLoaded: library 'gdalalljni' loaded.");
             return;
         } catch (UnsatisfiedLinkError e1) {
             if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.log(Level.FINE, "Failed to load the GDAL native libs from \"gdalalljni\". " +
-                        "Falling back to \"gdaljni\".\n" +
-                        e1.toString());
-            }
-            try {
-                System.loadLibrary("gdaljni");
-                LOGGER.log(Level.FINE, "ensureGDALLibraryLoaded: library 'gdaljni' loaded.");
-                return;
-            } catch (UnsatisfiedLinkError e2) {
-                LOGGER.log(Level.FINE,"ensureGDALLibraryLoaded: could not load 'gdalalljni' or 'gdaljni' .");
-                // loadGDAL() will throw later when gdal is accessed
+                LOGGER.log(Level.FINE, "Failed to load the GDAL native libs from 'gdalalljni': " + e1.toString());
             }
         }
+        try {
+            System.loadLibrary("gdaljni");
+            LOGGER.log(Level.FINE, "ensureGDALLibraryLoaded: library 'gdaljni' loaded.");
+            return;
+        } catch (UnsatisfiedLinkError e2) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE,"ensureGDALLibraryLoaded: could not load 'gdalalljni' or 'gdaljni':" + e2.toString());
+            }
+        }
+        // loadGDAL() will throw later when gdal is accessed
     }
     
     /**

--- a/library/gdalframework/src/main/java/it/geosolutions/imageio/gdalframework/GDALUtilities.java
+++ b/library/gdalframework/src/main/java/it/geosolutions/imageio/gdalframework/GDALUtilities.java
@@ -610,7 +610,7 @@ public final class GDALUtilities {
         return available;
     }
 
-/**
+    /**
      * This will ensure that java has loaded the GDAL library (<code>gdalalljni</code> or <code>gdaljni</code>).
      * 
      * <ul>

--- a/library/geocore/pom.xml
+++ b/library/geocore/pom.xml
@@ -18,12 +18,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>it.geosolutions.imageio-ext</groupId>
       <artifactId>imageio-ext-utilities</artifactId>
       <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <test.maxHeapSize>512M</test.maxHeapSize>
     <kakadu.version>5.2.6</kakadu.version>
     <java.awt.headless>true</java.awt.headless>
-    <gdal.version>2.2.0</gdal.version>  
+    <gdal.version>3.4.0</gdal.version>  
   </properties>
 
   <!-- ======================================================== -->

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,8 @@
     <test.maxHeapSize>512M</test.maxHeapSize>
     <kakadu.version>5.2.6</kakadu.version>
     <java.awt.headless>true</java.awt.headless>
-    <gdal.version>3.2.0</gdal.version>  
+    <gdal.version>3.2.0</gdal.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <!-- ======================================================== -->
@@ -238,7 +239,7 @@
               <title>Custom Streams</title>
               <packages>it.geosolutions.imageio.stream*:it.geosolutions.io*</packages>
             </group>
-      <group>
+            <group>
               <title>Multithreaded ImageRead</title>
               <packages>
                it.geosolutions.imageio.imageioimpl.imagereadmt*
@@ -265,19 +266,7 @@
       </plugin>
     </plugins>
   </reporting>
-
-
-  <!--..................................-->
-  <!--    java.net Maven2 Repository    -->
-  <!--..................................-->
-  <!-- <distributionManagement>                                             -->
-  <!--  <repository>                                                        -->
-  <!--  <id>java.net-m2-repository</id>                                     -->
-  <!--      <url>java-net:/maven2-repository/trunk/www/repository/</url>    -->
-  <!--    </repository>                                                     -->
-  <!-- </distributionManagement>                                            -->
-    
-    
+   
   <!-- ======================================================== -->
   <!--                 Developers and contributors              -->
   <!-- ======================================================== -->
@@ -316,17 +305,6 @@
   <!--                     Plugin Repositories                  -->
   <!-- ======================================================== -->
   <pluginRepositories>
-    <pluginRepository>
-      <id>codehaus.org</id>
-      <name>CodeHaus Plugin Snapshots</name>
-      <url>http://snapshots.repository.codehaus.org</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
     <pluginRepository>
       <id>osgeo</id>
       <name>OSGeo Nexus Maven Repository</name>
@@ -414,10 +392,15 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.gdal</groupId>
+        <artifactId>gdal</artifactId>
+        <version>${gdal.version}</version>
+      </dependency>
+      <!--dependency>
        <groupId>it.geosolutions.imageio-ext</groupId>
        <artifactId>imageio-ext-gdal-bindings</artifactId>
        <version>${gdal.version}</version>
-     </dependency>
+     </dependency-->
      <dependency>
        <groupId>it.geosolutions.imageio-ext</groupId>
        <artifactId>imageio-ext-kakadujni</artifactId>
@@ -493,14 +476,43 @@
     <!-- ========================================================= -->
     <pluginManagement>
       <plugins>
-	<plugin>
-	 <groupId>org.apache.maven.plugins</groupId>
-	 <artifactId>maven-eclipse-plugin</artifactId>
-	 <version>2.5</version>
-    </plugin>
+        <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+           <artifactId>maven-eclipse-plugin</artifactId>
+           <version>2.5</version>
+        </plugin>
+        <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+           <artifactId>maven-compiler-plugin</artifactId>
+           <version>3.10.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.10.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0-M5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.2.2</version>
+        </plugin>
       </plugins>
     </pluginManagement>
-      
    
     <plugins>
       <!-- ======================================================= -->
@@ -532,9 +544,9 @@
       </plugin>
       
       <plugin>
-          <inherited>true</inherited>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
+          <inherited>true</inherited>
           <configuration>
            <attach>true</attach>
           </configuration>
@@ -547,10 +559,10 @@
            </execution>
           </executions>
      </plugin>
-	<!-- artifact assembly -->
-      <plugin>
+     <!-- artifact assembly -->
+     <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.1</version>
           <configuration>
            <descriptors>
             <descriptor>release/src.xml</descriptor>
@@ -559,7 +571,7 @@
            <finalName>imageio-ext-${project.version}</finalName>
            <outputDirectory>${project.build.directory}/release</outputDirectory>
           </configuration>
-       </plugin>
+      </plugin>
     </plugins>
    
   <!-- ======================================================== -->

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <test.maxHeapSize>512M</test.maxHeapSize>
     <kakadu.version>5.2.6</kakadu.version>
     <java.awt.headless>true</java.awt.headless>
-    <gdal.version>3.4.0</gdal.version>  
+    <gdal.version>3.2.0</gdal.version>  
   </properties>
 
   <!-- ======================================================== -->


### PR DESCRIPTION
This PR updates to gdal 3.2.0 bindings:

Downstream PR (each will need to be updated to the release version of imageio-ext when this PR is merged):

- https://github.com/geotools/geotools/pull/3808
- https://github.com/GeoWebCache/geowebcache/pull/1024
- https://github.com/geoserver/geoserver/pull/5704