### PR TITLE
Link to HTTPS maven repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
     <repository>
       <id>jboss</id>
       <name>jboss</name>
-      <url>http://repository.jboss.org/maven2/</url>
+      <url>https://repository.jboss.org/maven2/</url>
     </repository>
     <repository>
       <id>osgeo</id>


### PR DESCRIPTION
Maven 3.8.1 blocks access to repositories using HTTP by default, see https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291. Update the <repository> element for jboss to use HTTPS instead of HTTP