### PR TITLE
Add HTTP proxy support for the HTTP RangeReader

### DIFF
--- a/plugin/cog/cog-rangereader-http/src/main/java/it/geosolutions/imageioimpl/plugins/cog/HttpClientFactory.java
+++ b/plugin/cog/cog-rangereader-http/src/main/java/it/geosolutions/imageioimpl/plugins/cog/HttpClientFactory.java
@@ -21,6 +21,7 @@ import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 
 import java.util.concurrent.TimeUnit;
+import java.net.Proxy;
 
 /**
  *  Utility class to assist building OkHttp client.  OkHttp clients should be singletons and re-used.
@@ -49,6 +50,11 @@ public class HttpClientFactory {
         OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder()
                 .dispatcher(dispatcher)
                 .connectionPool(connectionPool);
+
+        Proxy proxy = configProps.getHttpProxy();
+        if(proxy != null) {
+            clientBuilder.proxy(proxy);
+        }
 
         client = clientBuilder.build();
         return client;

--- a/plugin/cog/cog-rangereader-http/src/main/java/it/geosolutions/imageioimpl/plugins/cog/HttpConfigurationProperties.java
+++ b/plugin/cog/cog-rangereader-http/src/main/java/it/geosolutions/imageioimpl/plugins/cog/HttpConfigurationProperties.java
@@ -16,6 +16,10 @@
  */
 package it.geosolutions.imageioimpl.plugins.cog;
 
+import java.net.Proxy;
+import java.net.SocketAddress;
+import java.net.InetSocketAddress;
+
 /**
  * Provides configuration properties for the OkHttp client.  Attempts to read environment variables containing
  * connection settings and if not found, will fallback to attempting to read system properties.  If still not found,
@@ -30,11 +34,15 @@ public class HttpConfigurationProperties {
     private int maxRequestsPerHost;
     private int maxIdleConnections;
     private int keepAliveDuration;
+    private String httpProxyHost;
+    private int httpProxyPort;
 
     public final String HTTP_MAX_REQUESTS = "IIO_HTTP_MAX_REQUESTS";
     public final String HTTP_MAX_REQUESTS_PER_HOST = "IIO_HTTP_MAX_REQUESTS_PER_HOST";
     public final String HTTP_MAX_IDLE_CONNECTIONS = "IIO_HTTP_MAX_IDLE_CONNECTIONS";
     public final String HTTP_KEEP_ALIVE_TIME = "IIO_HTTP_KEEP_ALIVE_TIME";
+    public final String HTTP_PROXY_HOST = "HTTP_PROXY_HOST";
+    public final String HTTP_PROXY_PORT = "HTTP_PROXY_PORT";
 
     public HttpConfigurationProperties() {
         maxRequests = Integer.parseInt(
@@ -45,6 +53,8 @@ public class HttpConfigurationProperties {
                 PropertyLocator.getEnvironmentValue(HTTP_MAX_IDLE_CONNECTIONS, "5"));
         keepAliveDuration = Integer.parseInt(
                 PropertyLocator.getEnvironmentValue(HTTP_KEEP_ALIVE_TIME, "60"));
+        httpProxyHost = PropertyLocator.getEnvironmentValue(HTTP_PROXY_HOST, null);
+        httpProxyPort = Integer.parseInt(PropertyLocator.getEnvironmentValue(HTTP_PROXY_PORT, "3128"));
     }
 
     public int getMaxRequests() {
@@ -61,5 +71,15 @@ public class HttpConfigurationProperties {
 
     public int getKeepAliveDuration() {
         return keepAliveDuration;
+    }
+
+    public Proxy getHttpProxy() {
+        if(httpProxyHost != null) {
+            SocketAddress addr = new InetSocketAddress(this.httpProxyHost, this.httpProxyPort);
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, addr);
+            return proxy;
+        } else {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
I have a server on an internal network that can only reach the internet through an http proxy so requests to get COGs on the internet were failing. 

I updated the HTTP client in cog-rangereader-http to use a proxy if the HTTP_PROXY_HOST and HTTP_PROXY_PORT environment variables are set. This has been working fine on my own setup, but I'm not sure how to write a good test for this. 