### PR TITLE
Upgrade AWS SDK 2.9.24 -> 2.20.73

### DIFF
--- a/plugin/cog/pom.xml
+++ b/plugin/cog/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <okhttp.version>4.2.0</okhttp.version>
-        <aws.version>2.9.24</aws.version>
+        <aws.version>2.20.73</aws.version>
         <ehcache.version>3.4.0</ehcache.version>
         <online.skip.pattern>**/*OnlineTest.java</online.skip.pattern>
     </properties>


### PR DESCRIPTION
Upgrade the awssdk dependency used by `imageio-ext-cog-rangereader-s3` to support authentication through "IAM roles for service accounts".

The minimum required version is `2.10.11`, as indicated here: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html

This allows to use COG URI's without additional credentials configuration, as currently done for public/secrete keys, with additional support for IAM service accounts.