### PR TITLE
Fix building against Kakadu SDK Speedpack version

### DIFF
--- a/plugin/kakadujp2/src/main/java/it/geosolutions/util/KakaduUtilities.java
+++ b/plugin/kakadujp2/src/main/java/it/geosolutions/util/KakaduUtilities.java
@@ -386,7 +386,7 @@ public class KakaduUtilities {
      */
     private static int parseMajorVersion(String versionString) {
         String majorString = versionString.substring(0, versionString.indexOf('.'));
-        majorString = majorString.replaceAll("v", "");
+        majorString = majorString.replaceAll("vs?", "");
         int majorVersion = Integer.parseInt(majorString);
         return majorVersion;
     }


### PR DESCRIPTION
The speedpack version of the Kakadu SDK uses "vs" as version prefix, as opposed to the plain "v" prefix, tripping up `parseMajorVersion()`. This minor change allows it to parse the Speedpack version as well.

Kdu_global.java defines it as:
`public static final String KDU_CORE_VERSION = (String) "vs8.1";`