### PR TITLE
Adapt AbstractRangeReader and ExtCaches to clean up COG headers

### DIFF
--- a/plugin/cog/cog-commons/src/main/java/it/geosolutions/imageioimpl/plugins/cog/AbstractRangeReader.java
+++ b/plugin/cog/cog-commons/src/main/java/it/geosolutions/imageioimpl/plugins/cog/AbstractRangeReader.java
@@ -42,7 +42,7 @@ public abstract class AbstractRangeReader implements RangeReader {
     protected final static Map<String, byte[]> HEADERS_CACHE = new SoftValueHashMap<>();
     
     static {
-        ExtCaches.addListener(() -> HEADERS_CACHE.clear());
+        ExtCaches.addListener(HEADERS_CACHE::clear);
     }
 
     protected BasicAuthURI authUri;
@@ -58,6 +58,8 @@ public abstract class AbstractRangeReader implements RangeReader {
         // store the underlying uri too to avoid several getUri() calls around on the code
         this.uri = authUri.getUri();
         this.headerLength = headerLength;
+        // add a listener for disposal of that URI so that we can free resources in the HEADERS_CACHE
+        ExtCaches.addOrUpdateResourceListener(uri.toString(), (uri) -> HEADERS_CACHE.remove(uri));
     }
 
 


### PR DESCRIPTION
The current implementation of the `AbstractRangeReader` in the COG plugin does not provide any means of cleaning u cached COG headers after they are not used any more.  The only means of clearing the cache is through the `reset` method of `ExtCaches`, which cleans all COG headers (besides other resources from other classes).

This functionality is relevant for me in the following use cases:

- The COG headers accumulate in memory and lead to a waste of resources if there are many COGs which are not frequently used.

- I need to update COGs on the S3 storage, because my application creates the COGs based on user-defined rules. After the user changes a COG, I want to show them the updated result in a map view (via the Geoserver). Removing  the coveragestore on the Geoserver currently does not clean up the COG header cache, which leads to errors after re-creating the coveragestore because the cached headers do not belong to the real content of the COG any more.

Due to these problems I drafted a solution, where the `AbstractRangeReader` creates a separate listener in the `ExtCache` for every COG that is serves and users of imageio-ext can call a reset function for a specific COG on the `ExtCache`. 

I intend to use this new feature in the geotools `GeoTiffReader` as follows:
https://github.com/scriptator/geotools/commit/dbe2d61b5ea75d3805a6691967e9895864f37c17

So far I tested the changes manually for my use case but nothing more than that. Please give me some feedback on the idea.