### PR TITLE
Bug/fix s3 range reader read header error

### DIFF
--- a/plugin/cog/cog-rangereader-s3/src/main/java/it/geosolutions/imageioimpl/plugins/cog/S3RangeReader.java
+++ b/plugin/cog/cog-rangereader-s3/src/main/java/it/geosolutions/imageioimpl/plugins/cog/S3RangeReader.java
@@ -220,7 +220,7 @@ public class S3RangeReader extends AbstractRangeReader {
                     + S3ConfigurationProperties.S3_DOT_VH
                     + configProps.getRegion()
                     + S3ConfigurationProperties.AMAZON_AWS
-                    + "/" + configProps.getFilename());
+                    + "/" + configProps.getKey());
         }
         return super.getURL();
     }

--- a/plugin/cog/cog-rangereader-s3/src/test/java/it/geosolutions/imageio/cog/S3RangeReaderOnlineTest.java
+++ b/plugin/cog/cog-rangereader-s3/src/test/java/it/geosolutions/imageio/cog/S3RangeReaderOnlineTest.java
@@ -69,9 +69,11 @@ public class S3RangeReaderOnlineTest {
         //s3:// isn't recognized as a known protocol so a real URL can't be built on top of it.
         //Let's check that we can get a valid URL anyway (translating it to http protocol).
         URL url = reader.getURL();
+        BasicAuthURI uri = new BasicAuthURI(url);
         S3ConfigurationProperties configurationProperties = new S3ConfigurationProperties(uri.getUri().getScheme(), uri);
         assertEquals(region, configurationProperties.getRegion());
         assertEquals(bucket, configurationProperties.getBucket());
+        assertEquals(file, configurationProperties.getKey());
     }
 
     @Test


### PR DESCRIPTION
This fixes issue #300 by using `configProps.getKey()` insted of `configProps.getFilename()` in S3RangeReader::getURL() to create the URL