### PR TITLE
add IIO_S3_AWS_FORCE_PATH_STYLE environment variable to support minio s3 server

### DIFF
--- a/plugin/cog/cog-rangereader-s3/src/main/java/it/geosolutions/imageioimpl/plugins/cog/S3ClientFactory.java
+++ b/plugin/cog/cog-rangereader-s3/src/main/java/it/geosolutions/imageioimpl/plugins/cog/S3ClientFactory.java
@@ -83,6 +83,8 @@ public class S3ClientFactory {
                 getExecutor(configProps)
         ));
 
+        builder.forcePathStyle(configProps.getForcePathStyle());
+
         S3AsyncClient s3AsyncClient = builder.build();
         s3AsyncClients.put(region, s3AsyncClient);
         return s3AsyncClient;

--- a/plugin/cog/cog-rangereader-s3/src/main/java/it/geosolutions/imageioimpl/plugins/cog/S3ConfigurationProperties.java
+++ b/plugin/cog/cog-rangereader-s3/src/main/java/it/geosolutions/imageioimpl/plugins/cog/S3ConfigurationProperties.java
@@ -159,6 +159,7 @@ public class S3ConfigurationProperties {
     private int corePoolSize;
     private int maxPoolSize;
     private int keepAliveTime;
+    private boolean forcePathStyle;
 
     public final String AWS_S3_USER_KEY;
     public final String AWS_S3_PASSWORD_KEY;
@@ -167,6 +168,7 @@ public class S3ConfigurationProperties {
     public final String AWS_S3_CORE_POOL_SIZE_KEY;
     public final String AWS_S3_MAX_POOL_SIZE_KEY;
     public final String AWS_S3_KEEP_ALIVE_TIME;
+    public final String AWS_S3_FORCE_PATH_STYLE;
 
     private final static Logger LOGGER = Logger.getLogger(S3ConfigurationProperties.class.getName());
 
@@ -179,6 +181,7 @@ public class S3ConfigurationProperties {
         AWS_S3_CORE_POOL_SIZE_KEY = "IIO_" + this.alias + "_AWS_CORE_POOL_SIZE";
         AWS_S3_MAX_POOL_SIZE_KEY = "IIO_" + this.alias + "_AWS_MAX_POOL_SIZE";
         AWS_S3_KEEP_ALIVE_TIME = "IIO_" + this.alias + "_AWS_KEEP_ALIVE_TIME";
+        AWS_S3_FORCE_PATH_STYLE = "IIO_" + this.alias + "_AWS_FORCE_PATH_STYLE";
 
         user = PropertyLocator.getEnvironmentValue(AWS_S3_USER_KEY, null);
         password = PropertyLocator.getEnvironmentValue(AWS_S3_PASSWORD_KEY, null);
@@ -190,6 +193,8 @@ public class S3ConfigurationProperties {
                 PropertyLocator.getEnvironmentValue(AWS_S3_MAX_POOL_SIZE_KEY, "128"));
         keepAliveTime = Integer.parseInt(
                 PropertyLocator.getEnvironmentValue(AWS_S3_KEEP_ALIVE_TIME, "10"));
+        forcePathStyle = Boolean.parseBoolean(
+                PropertyLocator.getEnvironmentValue(AWS_S3_FORCE_PATH_STYLE, "false"));
 
         if (cogUri.getUser() != null && cogUri.getPassword()!= null) {
             user = cogUri.getUser();
@@ -299,5 +304,9 @@ public class S3ConfigurationProperties {
 
     public int getKeepAliveTime() {
         return keepAliveTime;
+    }
+
+    public boolean getForcePathStyle() {
+        return forcePathStyle;
     }
 }


### PR DESCRIPTION
Add environment variable to set the forcePathStyle s3 client property.

We use a minio s3 server as a storage backend for geotiffs in geoserver. It does not allow virtual hosts for bucket addressing in our configuration. Previously the aws s3 sdk did only default to virtual host style addressing when the hostname started with "s3.". This was recently changed I think, so now it always uses virtual host style bucket addressing. This MR would add an environment variable to force the underlying amazon aws s3 sdk to use path based addressing. A similar problem was mentioned in issue #223. 
I would welcome any kind of feedback. 