### PR TITLE
Upgrade cog-rangereader-azure to azure-sdk:12.27.1

### DIFF
--- a/plugin/cog/cog-rangereader-azure/pom.xml
+++ b/plugin/cog/cog-rangereader-azure/pom.xml
@@ -26,10 +26,8 @@
             <artifactId>imageio-ext-cog-commons</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.microsoft.azure</groupId>
+            <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
-            <version>11.0.0</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/plugin/cog/cog-rangereader-azure/src/main/java/it/geosolutions/imageioimpl/plugins/cog/AzureConfigurationProperties.java
+++ b/plugin/cog/cog-rangereader-azure/src/main/java/it/geosolutions/imageioimpl/plugins/cog/AzureConfigurationProperties.java
@@ -16,13 +16,12 @@
  */
 package it.geosolutions.imageioimpl.plugins.cog;
 
-import com.microsoft.azure.storage.blob.BlobURLParts;
-import com.microsoft.azure.storage.blob.URLParser;
-import it.geosolutions.imageio.core.BasicAuthURI;
-
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.UnknownHostException;
+
+import com.azure.storage.blob.BlobUrlParts;
+
+import it.geosolutions.imageio.core.BasicAuthURI;
 
 /**
  * Helps locate configuration properties in system/environment for use in building Azure client.
@@ -40,7 +39,7 @@ public class AzureConfigurationProperties {
     private String accountName;
     private String accountKey;
     private Integer maxConnections = 64;
-    private Boolean useHTTPS = Boolean.TRUE;
+    private boolean useHTTPS = true;
     private String serviceURL = null;
 
     AzureConfigurationProperties(BasicAuthURI cogUri) {
@@ -52,33 +51,32 @@ public class AzureConfigurationProperties {
 
         if (path.startsWith("https")) {
             // replace for quicker finding
-            path = path.replace("https", "http");
+            path = path.replaceFirst("https", "http");
             useHTTPS = true;
         }
 
-        BlobURLParts parts = null;
         try {
-            parts = URLParser.parse(uri.toURL());
-            container = parts.containerName();
-            String blobName = parts.blobName();
+            BlobUrlParts parts = BlobUrlParts.parse(uri.toURL());
+            container = parts.getBlobContainerName();
+            String blobName = parts.getBlobName();
             int lastIndex = blobName.lastIndexOf("/");
             if (lastIndex > 0) {
                 prefix = blobName.substring(0, lastIndex);
             }
-            String host = parts.host();
+            String host = parts.getHost();
             int blobcoreIdx = host.indexOf("." + AzureClient.AZURE_URL_BASE);
             if (blobcoreIdx > 0) {
                 accountName = host.substring(0, blobcoreIdx);
             }
 
-        } catch (UnknownHostException| MalformedURLException e) {
+        } catch (IllegalStateException| MalformedURLException e) {
             throw new RuntimeException("Unable to parse the provided uri " + path + "due to " + e.getLocalizedMessage());
         }
 
-        if (container == null) {
+        if (container == null) {//REVISIT: dead code
             container = PropertyLocator.getEnvironmentValue(AZURE_ACCOUNT_CONTAINER, null);
         }
-        if (prefix == null) {
+        if (prefix == null) {//REVISIT: dead code
             prefix = PropertyLocator.getEnvironmentValue(AZURE_ACCOUNT_PREFIX, null);
         }
         if (cogUri.getUser() != null && cogUri.getPassword()!= null) {
@@ -86,13 +84,13 @@ public class AzureConfigurationProperties {
             accountKey = cogUri.getPassword();
         }
 
-        if (accountName == null) {
+        if (accountName == null) {//REVISIT: dead code
             accountName = PropertyLocator.getEnvironmentValue(AZURE_ACCOUNT_NAME, null);
         }
         if (accountKey == null) {
             accountKey = PropertyLocator.getEnvironmentValue(AZURE_ACCOUNT_KEY, null);
         }
-        if (maxConnections == null) {
+        if (maxConnections == null) {//REVISIT: dead code
             maxConnections = Integer.parseInt(PropertyLocator.getEnvironmentValue(AZURE_MAX_CONNECTIONS, "5"));
         }
 
@@ -138,11 +136,11 @@ public class AzureConfigurationProperties {
         this.maxConnections = maxConnections;
     }
 
-    public Boolean isUseHTTPS() {
+    public boolean isUseHTTPS() {
         return useHTTPS;
     }
 
-    public void setUseHTTPS(Boolean useHTTPS) {
+    public void setUseHTTPS(boolean useHTTPS) {
         this.useHTTPS = useHTTPS;
     }
 

--- a/plugin/cog/cog-rangereader-azure/src/test/java/it/geosolutions/imageioimpl/plugins/cog/AzureConfigurationPropertiesTest.java
+++ b/plugin/cog/cog-rangereader-azure/src/test/java/it/geosolutions/imageioimpl/plugins/cog/AzureConfigurationPropertiesTest.java
@@ -1,0 +1,55 @@
+/*
+ *    ImageI/O-Ext - OpenSource Java Image translation Library
+ *    http://www.geo-solutions.it/
+ *    https://github.com/geosolutions-it/imageio-ext
+ *    (C) 2022, GeoSolutions
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    either version 3 of the License, or (at your option) any later version.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package it.geosolutions.imageioimpl.plugins.cog;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import it.geosolutions.imageio.core.BasicAuthURI;
+
+public class AzureConfigurationPropertiesTest {
+
+    @Test
+    public void testPartsFromUrl() {
+        String azureUrl = "https://fakeaccount.blob.core.windows.net/cogtestdata/testvirtualfolder/land_topo_cog_jpeg_1024.tif";
+
+        AzureConfigurationProperties props = new AzureConfigurationProperties(new BasicAuthURI(azureUrl));
+        
+        assertTrue(props.isUseHTTPS());
+        assertEquals("fakeaccount", props.getAccountName());
+        assertEquals("cogtestdata", props.getContainer());
+        assertEquals("testvirtualfolder", props.getPrefix());
+        assertNull(props.getServiceURL());
+        assertEquals(Integer.valueOf(64), props.getMaxConnections());
+    }
+
+    @Test
+    public void testAccountKeyFromBaicAuthURI() {
+        String azureUrl = "https://fakeaccount.blob.core.windows.net/cogtestdata/testvirtualfolder/land_topo_cog_jpeg_1024.tif";
+        BasicAuthURI uri = new BasicAuthURI(azureUrl);
+        uri.setUser("testAccountName");
+        uri.setPassword("testAccountKey");
+        AzureConfigurationProperties props = new AzureConfigurationProperties(uri);
+        
+        assertTrue(props.isUseHTTPS());
+        assertEquals("testAccountName", props.getAccountName());
+        assertEquals("testAccountKey", props.getAccountKey());
+    }
+}

--- a/plugin/cog/cog-rangereader-azure/src/test/java/it/geosolutions/imageioimpl/plugins/cog/AzureRangeReaderOnlineTest.java
+++ b/plugin/cog/cog-rangereader-azure/src/test/java/it/geosolutions/imageioimpl/plugins/cog/AzureRangeReaderOnlineTest.java
@@ -16,9 +16,6 @@
  */
 package it.geosolutions.imageioimpl.plugins.cog;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.spy;
@@ -26,6 +23,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 public class AzureRangeReaderOnlineTest {
 

--- a/plugin/cog/pom.xml
+++ b/plugin/cog/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <okhttp.version>4.12.0</okhttp.version>
         <aws.version>2.24.13</aws.version>
+        <azure.version>12.27.1</azure.version>
         <ehcache.version>3.4.0</ehcache.version>
         <online.skip.pattern>**/*OnlineTest.java</online.skip.pattern>
     </properties>
@@ -92,7 +93,47 @@
                 <artifactId>ehcache</artifactId>
                 <version>${ehcache.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-storage-blob</artifactId>
+                <version>${azure.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
+    
+    <profiles>
+        <profile>
+            <!--
+             Converges the netty dependency version from cog-rangereader-s3 and cog-rangereader-azure
+             to a common version that works with both, so that both plugins can co-exist without
+             adding netty libs with slightly different versions to the dependencies.
 
+             From cog-rangereader-azure:
+
+             com.azure:azure-storage-blob:jar:12.27.1
+             +- com.azure:azure-core-http-netty:jar:1.15.3
+                +- io.netty:netty-handler:jar:4.1.110.Final
+
+             From cog-rangereader-s3:
+             software.amazon.awssdk:s3:jar:2.24.13
+             +- software.amazon.awssdk:netty-nio-client:jar:2.24.13
+                +- io.netty:netty-codec-http:jar:4.1.107.Final
+            -->
+            <id>dependencyConvergence</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-bom</artifactId>
+                        <version>4.1.113.Final</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Upgrades from the legacy
`com.microsoft.azure:azure-storage-blob:11.0.0` SDK to the current version `com.azure:azure-storage-blob:12.27.1`.

A `dependencyConvergence` profile is added to the `imageio-ext-cog` parent pom to define a single netty version for both the s3 and the azure cog-readers.

```
    <profiles>
        <profile>
            <!--
             Converges the netty dependency version from cog-rangereader-s3 and cog-rangereader-azure
             to a common version that works with both, so that both plugins can co-exist without
             adding netty libs with slightly different versions to the dependencies.

             From cog-rangereader-azure:

             com.azure:azure-storage-blob:jar:12.27.1
             +- com.azure:azure-core-http-netty:jar:1.15.3
                +- io.netty:netty-handler:jar:4.1.110.Final

             From cog-rangereader-s3:
             software.amazon.awssdk:s3:jar:2.24.13
             +- software.amazon.awssdk:netty-nio-client:jar:2.24.13
                +- io.netty:netty-codec-http:jar:4.1.107.Final
            -->
            <id>dependencyConvergence</id>
            <activation>
                <activeByDefault>true</activeByDefault>
            </activation>
            <dependencyManagement>
                <dependencies>
                    <dependency>
                        <groupId>io.netty</groupId>
                        <artifactId>netty-bom</artifactId>
                        <version>4.1.113.Final</version>
                        <type>pom</type>
                        <scope>import</scope>
                    </dependency>
                </dependencies>
            </dependencyManagement>
        </profile>
    </profiles>
```

> This pull request complements https://github.com/GeoWebCache/geowebcache/pull/1316 in the context of GeoServer having compatible transitive dependencies on azure-sdk and their netty dependencies.
