### PR TITLE
ImageIO-Ext update for JAI to ImageN Rename of classes and constants

### DIFF
--- a/library/gdalframework/src/main/java/it/geosolutions/imageio/gdalframework/GDALUtilities.java
+++ b/library/gdalframework/src/main/java/it/geosolutions/imageio/gdalframework/GDALUtilities.java
@@ -18,7 +18,7 @@ package it.geosolutions.imageio.gdalframework;
 
 import it.geosolutions.imageio.imageioimpl.EnhancedImageReadParam;
 import it.geosolutions.imageio.utilities.ImageIOUtilities;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.NotAColorSpace;
 import org.eclipse.imagen.RasterFactory;
 import org.eclipse.imagen.media.imageread.ImageReadDescriptor;
@@ -590,7 +590,7 @@ public final class GDALUtilities {
      * <p>
      */
     public static Dimension toTileSize(final Dimension size) {
-        Dimension defaultSize = JAI.getDefaultTileSize();
+        Dimension defaultSize = ImageN.getDefaultTileSize();
         if (defaultSize == null) {
             defaultSize = DEFAULT_TILE_SIZE;
         }

--- a/library/streams/src/test/java/it/geosolutions/imageio/stream/ImageInputStreamTest.java
+++ b/library/streams/src/test/java/it/geosolutions/imageio/stream/ImageInputStreamTest.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageInputStream;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.RenderedOp;
 import javax.swing.JFrame;
 
@@ -65,7 +65,7 @@ public class ImageInputStreamTest  {
 		// new FileInputStream(TestData.file(this, "sample.jpeg")));
 		// final ImageInputStreamAdapter adapter = new ImageInputStreamAdapter(
 		// stream);
-		// final RenderedOp image= JAI.create("ImageRead", adapter);
+		// final RenderedOp image= ImageN.create("ImageRead", adapter);
 		// visualize(image,"testURLImageInputStreamSpi");
 		// } catch (IOException e) {
 		// LOGGER.log(Level.SEVERE, e.getLocalizedMessage(), e);
@@ -230,7 +230,7 @@ public class ImageInputStreamTest  {
 		try {
 			final URL url = TestData.url(this, "sample.jpeg");
 			final ImageInputStream stream = ImageIO.createImageInputStream(url);
-			final RenderedOp image = JAI.create("ImageRead", stream);
+			final RenderedOp image = ImageN.create("ImageRead", stream);
 			if (TestData.isInteractiveTest())
 				visualize(image, "testURLImageInputStreamSpi");
 			else
@@ -255,7 +255,7 @@ public class ImageInputStreamTest  {
 		try {
 			final File url = TestData.file(this, "sample.jpeg");
 			final ImageInputStream stream = ImageIO.createImageInputStream(url);
-			final RenderedOp image = JAI.create("ImageRead", stream);
+			final RenderedOp image = ImageN.create("ImageRead", stream);
 			if (TestData.isInteractiveTest())
 				visualize(image, "testFileImageInputStreamExtImpl");
 			else
@@ -310,7 +310,7 @@ public class ImageInputStreamTest  {
         try {
             final String url = TestData.url(this, "sample.jpeg").toString();
             final ImageInputStream stream = ImageIO.createImageInputStream(url);
-            final RenderedOp image = JAI.create("ImageRead", stream);
+            final RenderedOp image = ImageN.create("ImageRead", stream);
             if (TestData.isInteractiveTest())
                 visualize(image, "testURLImageInputStreamSpi");
             else

--- a/library/streams/src/test/java/it/geosolutions/imageio/stream/ImageOutputStreamTest.java
+++ b/library/streams/src/test/java/it/geosolutions/imageio/stream/ImageOutputStreamTest.java
@@ -33,7 +33,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.stream.FileImageInputStream;
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.ImageOutputStream;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -64,7 +64,7 @@ public class ImageOutputStreamTest {
 
 
         // read test image
-        RenderedImage image = JAI.create("ImageRead", TestData.file(this, "sample.jpeg"));
+        RenderedImage image = ImageN.create("ImageRead", TestData.file(this, "sample.jpeg"));
 
         // try to encode a jpeg
         BufferedImage test=null;

--- a/library/utilities/src/main/java/it/geosolutions/imageio/utilities/ImageIOUtilities.java
+++ b/library/utilities/src/main/java/it/geosolutions/imageio/utilities/ImageIOUtilities.java
@@ -834,10 +834,10 @@ public class ImageIOUtilities {
 	 */
 	public synchronized static void setNativeAccelerationAllowed(final String operation,
 	                                                             final boolean  allowed,
-	                                                             final ImageN jai)
+	                                                             final ImageN imagen)
 	{
 	    final String product = "org.eclipse.imagen.media";
-	    final OperationRegistry registry = jai.getOperationRegistry();
+	    final OperationRegistry registry = imagen.getOperationRegistry();
 	
 	    // TODO: Check if we can remove SuppressWarnings with a future ImageN version.
 	    @SuppressWarnings("unchecked")

--- a/library/utilities/src/main/java/it/geosolutions/imageio/utilities/ImageIOUtilities.java
+++ b/library/utilities/src/main/java/it/geosolutions/imageio/utilities/ImageIOUtilities.java
@@ -16,7 +16,7 @@
  */
 package it.geosolutions.imageio.utilities;
 
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.NotAColorSpace;
 import org.eclipse.imagen.OperationRegistry;
 import org.eclipse.imagen.PlanarImage;
@@ -280,8 +280,8 @@ public class ImageIOUtilities {
      * Visualize the image, after rescaling its values, given a threshold for
      * the ROI. This is useful to rescale an image coming from a source which
      * may contain noDataValues. The ROI threshold allows to set a minimal value
-     * to be included in the computation of the future JAI extrema operation
-     * used before the JAI rescale operation.
+     * to be included in the computation of the future ImageN extrema operation
+     * used before the ImageN rescale operation.
      * 
      * @param image
      *                RenderedImage to visualize
@@ -300,7 +300,7 @@ public class ImageIOUtilities {
             pb.add(roi); // The region of the image to scan
 
         // Perform the extrema operation on the source image
-        RenderedOp op = JAI.create("extrema", pb);
+        RenderedOp op = ImageN.create("extrema", pb);
 
         // Retrieve both the maximum and minimum pixel value
         double[][] extrema = (double[][]) op.getProperty("extrema");
@@ -314,12 +314,12 @@ public class ImageIOUtilities {
         pbRescale.add(scale);
         pbRescale.add(offset);
         pbRescale.addSource(image);
-        RenderedOp rescaledImage = JAI.create("Rescale", pbRescale);
+        RenderedOp rescaledImage = ImageN.create("Rescale", pbRescale);
 
         ParameterBlock pbConvert = new ParameterBlock();
         pbConvert.addSource(rescaledImage);
         pbConvert.add(DataBuffer.TYPE_BYTE);
-        RenderedOp destImage = JAI.create("format", pbConvert);
+        RenderedOp destImage = ImageN.create("format", pbConvert);
         visualize(destImage, title);
     }
 
@@ -417,7 +417,7 @@ public class ImageIOUtilities {
 			// Look for JDK core ImageWriterSpi's
 			if (provider.getVendorName().startsWith("Sun Microsystems")
 					&& desc.equalsIgnoreCase(provider.getDescription(locale)) &&
-					// not JAI Image I/O plugins
+					// not ImageN Image I/O plugins
 					!provider.getPluginClassName().startsWith(jiioPath)) {
 
 				// Get the formatNames supported by this Spi
@@ -811,10 +811,10 @@ public class ImageIOUtilities {
 	}
 
 	/**
-	 * Allows or disallow native acceleration for the specified operation on the given JAI instance.
-	 * By default, JAI uses hardware accelerated methods when available. For example, it make use of
+	 * Allows or disallow native acceleration for the specified operation on the given ImageN instance.
+	 * By default, ImageN uses hardware accelerated methods when available. For example, it make use of
 	 * MMX instructions on Intel processors. Unluckily, some native method crash the Java Virtual
-	 * Machine under some circumstances. For example on JAI 1.1.2, the {@code "Affine"} operation on
+	 * Machine under some circumstances. For example on ImageN 1.1.2, the {@code "Affine"} operation on
 	 * an image with float data type, bilinear interpolation and an {@link org.eclipse.imagen.ImageLayout}
 	 * rendering hint cause an exception in medialib native code. Disabling the native acceleration
 	 * (i.e using the pure Java version) is a convenient workaround until Sun fix the bug.
@@ -828,18 +828,18 @@ public class ImageIOUtilities {
 	 * @param operation The operation name (e.g. {@code "Affine"}).
 	 * @param allowed {@code false} to disallow native acceleration.
 	 * @param jai The instance of {@link JAI} we are going to work on. This argument can be
-	 *        omitted for the {@linkplain JAI#getDefaultInstance default JAI instance}.
+	 *        omitted for the {@linkplain JAI#getDefaultInstance default ImageN instance}.
 	 *
 	 * @see <a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4906854">JAI bug report 4906854</a>
 	 */
 	public synchronized static void setNativeAccelerationAllowed(final String operation,
 	                                                             final boolean  allowed,
-	                                                             final JAI jai)
+	                                                             final ImageN jai)
 	{
 	    final String product = "org.eclipse.imagen.media";
 	    final OperationRegistry registry = jai.getOperationRegistry();
 	
-	    // TODO: Check if we can remove SuppressWarnings with a future JAI version.
+	    // TODO: Check if we can remove SuppressWarnings with a future ImageN version.
 	    @SuppressWarnings("unchecked")
 	    final List<RenderedImageFactory> factories = registry.getOrderedFactoryList(
 	            RenderedRegistryMode.MODE_NAME, operation, product);
@@ -875,14 +875,14 @@ public class ImageIOUtilities {
 
 	/**
 	 * Allows or disallow native acceleration for the specified operation on the
-	 * {@linkplain JAI#getDefaultInstance default JAI instance}. This method is
+	 * {@linkplain JAI#getDefaultInstance default ImageN instance}. This method is
 	 * a shortcut for <code>{@linkplain #setNativeAccelerationAllowed(String,boolean,JAI)
-	 * setNativeAccelerationAllowed}(operation, allowed, JAI.getDefaultInstance())</code>.
+	 * setNativeAccelerationAllowed}(operation, allowed, ImageN.getDefaultInstance())</code>.
 	 *
 	 * @see #setNativeAccelerationAllowed(String, boolean, JAI)
 	 */
 	public static void setNativeAccelerationAllowed(final String operation, final boolean allowed) {
-	    setNativeAccelerationAllowed(operation, allowed, JAI.getDefaultInstance());
+	    setNativeAccelerationAllowed(operation, allowed, ImageN.getDefaultInstance());
 	}
 
 	public final static void checkNotNull (final Object checkMe, final String message){

--- a/library/utilities/src/main/java/it/geosolutions/imageio/utilities/ImageIOUtilities.java
+++ b/library/utilities/src/main/java/it/geosolutions/imageio/utilities/ImageIOUtilities.java
@@ -417,7 +417,7 @@ public class ImageIOUtilities {
 			// Look for JDK core ImageWriterSpi's
 			if (provider.getVendorName().startsWith("Sun Microsystems")
 					&& desc.equalsIgnoreCase(provider.getDescription(locale)) &&
-					// not ImageN Image I/O plugins
+					// not Image I/O plugins
 					!provider.getPluginClassName().startsWith(jiioPath)) {
 
 				// Get the formatNames supported by this Spi
@@ -814,7 +814,7 @@ public class ImageIOUtilities {
 	 * Allows or disallow native acceleration for the specified operation on the given ImageN instance.
 	 * By default, ImageN uses hardware accelerated methods when available. For example, it make use of
 	 * MMX instructions on Intel processors. Unluckily, some native method crash the Java Virtual
-	 * Machine under some circumstances. For example on ImageN 1.1.2, the {@code "Affine"} operation on
+	 * Machine under some circumstances. For example on ImageN, the {@code "Affine"} operation on
 	 * an image with float data type, bilinear interpolation and an {@link org.eclipse.imagen.ImageLayout}
 	 * rendering hint cause an exception in medialib native code. Disabling the native acceleration
 	 * (i.e using the pure Java version) is a convenient workaround until Sun fix the bug.

--- a/library/utilities/src/main/java/it/geosolutions/imageio/utilities/Utilities.java
+++ b/library/utilities/src/main/java/it/geosolutions/imageio/utilities/Utilities.java
@@ -179,7 +179,7 @@ public final class Utilities {
 	 * Allows or disallow native acceleration for the specified operation on the given ImageN instance.
 	 * By default, ImageN uses hardware accelerated methods when available. For example, it make use of
 	 * MMX instructions on Intel processors. Unluckily, some native method crash the Java Virtual
-	 * Machine under some circumstances. For example on ImageN 1.1.2, the {@code "Affine"} operation on
+	 * Machine under some circumstances. For example on ImageN, the {@code "Affine"} operation on
 	 * an image with float data type, bilinear interpolation and an {@link org.eclipse.imagen.ImageLayout}
 	 * rendering hint cause an exception in medialib native code. Disabling the native acceleration
 	 * (i.e using the pure Java version) is a convenient workaround until Sun fix the bug.

--- a/library/utilities/src/main/java/it/geosolutions/imageio/utilities/Utilities.java
+++ b/library/utilities/src/main/java/it/geosolutions/imageio/utilities/Utilities.java
@@ -22,7 +22,7 @@ package it.geosolutions.imageio.utilities;
 import java.io.File;
 import java.net.URL;
 
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 
 /**
  * Simple class for utility methods.
@@ -176,10 +176,10 @@ public final class Utilities {
 	}
     
     /**
-	 * Allows or disallow native acceleration for the specified operation on the given JAI instance.
-	 * By default, JAI uses hardware accelerated methods when available. For example, it make use of
+	 * Allows or disallow native acceleration for the specified operation on the given ImageN instance.
+	 * By default, ImageN uses hardware accelerated methods when available. For example, it make use of
 	 * MMX instructions on Intel processors. Unluckily, some native method crash the Java Virtual
-	 * Machine under some circumstances. For example on JAI 1.1.2, the {@code "Affine"} operation on
+	 * Machine under some circumstances. For example on ImageN 1.1.2, the {@code "Affine"} operation on
 	 * an image with float data type, bilinear interpolation and an {@link org.eclipse.imagen.ImageLayout}
 	 * rendering hint cause an exception in medialib native code. Disabling the native acceleration
 	 * (i.e using the pure Java version) is a convenient workaround until Sun fix the bug.
@@ -193,23 +193,23 @@ public final class Utilities {
 	 * @param operation The operation name (e.g. {@code "Affine"}).
 	 * @param allowed {@code false} to disallow native acceleration.
 	 * @param jai The instance of {@link JAI} we are going to work on. This argument can be
-	 *        omitted for the {@linkplain JAI#getDefaultInstance default JAI instance}.
+	 *        omitted for the {@linkplain JAI#getDefaultInstance default ImageN instance}.
 	 *
 	 * @see <a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4906854">JAI bug report 4906854</a>
 	 * @deprecated Use {@link ImageIOUtilities#setNativeAccelerationAllowed(String,boolean,JAI)} instead
 	 */
 	public synchronized static void setNativeAccelerationAllowed(final String operation,
 	                                                             final boolean  allowed,
-	                                                             final JAI jai)
+	                                                             final ImageN jai)
 	{
 		ImageIOUtilities.setNativeAccelerationAllowed(operation, allowed, jai);
 	}
 
     /**
 	 * Allows or disallow native acceleration for the specified operation on the
-	 * {@linkplain JAI#getDefaultInstance default JAI instance}. This method is
+	 * {@linkplain JAI#getDefaultInstance default ImageN instance}. This method is
 	 * a shortcut for <code>{@linkplain #setNativeAccelerationAllowed(String,boolean,JAI)
-	 * setNativeAccelerationAllowed}(operation, allowed, JAI.getDefaultInstance())</code>.
+	 * setNativeAccelerationAllowed}(operation, allowed, ImageN.getDefaultInstance())</code>.
 	 *
 	 * @see #setNativeAccelerationAllowed(String, boolean, JAI)
 	 * @deprecated Use {@link ImageIOUtilities#setNativeAccelerationAllowed(String,boolean)} instead

--- a/library/utilities/src/main/java/it/geosolutions/imageio/utilities/Utilities.java
+++ b/library/utilities/src/main/java/it/geosolutions/imageio/utilities/Utilities.java
@@ -200,9 +200,9 @@ public final class Utilities {
 	 */
 	public synchronized static void setNativeAccelerationAllowed(final String operation,
 	                                                             final boolean  allowed,
-	                                                             final ImageN jai)
+	                                                             final ImageN imagen)
 	{
-		ImageIOUtilities.setNativeAccelerationAllowed(operation, allowed, jai);
+		ImageIOUtilities.setNativeAccelerationAllowed(operation, allowed, imagen);
 	}
 
     /**

--- a/plugin/arcgrid/src/main/java/it/geosolutions/imageio/plugins/arcgrid/raster/AsciiGridRaster.java
+++ b/plugin/arcgrid/src/main/java/it/geosolutions/imageio/plugins/arcgrid/raster/AsciiGridRaster.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 import javax.imageio.ImageReadParam;
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.ImageOutputStream;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.RasterFactory;
 import org.eclipse.imagen.TileFactory;
 import org.eclipse.imagen.iterator.RectIter;
@@ -641,7 +641,7 @@ public abstract class AsciiGridRaster {
 		// Number of samples to count before I find useful data
 		final long tileBeginsAtSampleIndex = (nCols * srcRegionYOffset);
 
-		final TileFactory factory = (TileFactory) JAI.getDefaultInstance().getRenderingHint(JAI.KEY_TILE_FACTORY);
+		final TileFactory factory = (TileFactory) ImageN.getDefaultInstance().getRenderingHint(ImageN.KEY_TILE_FACTORY);
 		if (factory != null)
 			raster = factory.createTile(RasterFactory.createBandedSampleModel(
 					java.awt.image.DataBuffer.TYPE_DOUBLE, dstWidth, dstHeight,

--- a/plugin/arcgrid/src/test/java/it/geosolutions/imageio/plugins/arcgrid/AsciiGridTest.java
+++ b/plugin/arcgrid/src/test/java/it/geosolutions/imageio/plugins/arcgrid/AsciiGridTest.java
@@ -24,7 +24,7 @@ import it.geosolutions.resources.TestData;
 import junit.framework.Assert;
 import junit.framework.TestCase;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 import org.eclipse.imagen.media.imageread.ImageReadDescriptor;
 import org.w3c.dom.Node;
@@ -115,7 +115,7 @@ public class AsciiGridTest extends TestCase {
 		});
         File inputDirectory = TestData.file(this, ".");
         for(String fileName:files){
-	        ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+	        ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
 	        pbjImageRead.setParameter("Input", new File(inputDirectory,fileName));
 	        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 	        if (TestData.isInteractiveTest())
@@ -134,7 +134,7 @@ public class AsciiGridTest extends TestCase {
 	        // Reading it back
 	        //
 	        // //
-	        pbjImageRead = new ParameterBlockJAI("ImageRead");
+	        pbjImageRead = new ParameterBlockImageN("ImageRead");
 	        pbjImageRead.setParameter("Input", foutput);
 	        RenderedOp image2 = ImageN.create("ImageRead", pbjImageRead);
 	        title = new String("Read Back the just written image");
@@ -156,7 +156,7 @@ public class AsciiGridTest extends TestCase {
         String title = new String("Simple ImageN ImageRead operation test");
 
         File testFile = TestData.file(this, "095b_dem_90m.asc");
-        ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+        ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", testFile);
         RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
         if (TestData.isInteractiveTest()) {
@@ -189,7 +189,7 @@ public class AsciiGridTest extends TestCase {
         // Reading it back
         //
         // //
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", foutput);
         RenderedOp image2 = ImageN.create("ImageRead", pbjImageRead);
         title = new String("Read Back the just written image");
@@ -216,7 +216,7 @@ public class AsciiGridTest extends TestCase {
             File inputFile = TestData.file(this, "spearfish.asc.gz");
             final GZIPInputStream stream = new GZIPInputStream(
                     new FileInputStream(inputFile));
-            ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+            ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
             pbjImageRead.setParameter("Input", stream);
             RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
             if (TestData.isInteractiveTest())
@@ -246,7 +246,7 @@ public class AsciiGridTest extends TestCase {
         // Preparing ImageRead parameters
         //
         File inputFile = TestData.file(this, "dem.asc");
-        ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+        ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", inputFile);
         ImageReadParam irp = new ImageReadParam();
 
@@ -307,7 +307,7 @@ public class AsciiGridTest extends TestCase {
         // Preparing ImageRead parameters
         //
         inputFile = TestData.file(this, "spearfish_dem.arx");
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", inputFile);
         irp = new ImageReadParam();
 
@@ -362,7 +362,7 @@ public class AsciiGridTest extends TestCase {
         // Preparing ImageRead parameters
         //
         inputFile = TestData.file(this, "SWAN_NURC_LigurianSeaL07_HSIGN.asc");
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", inputFile);
         irp = new ImageReadParam();
 

--- a/plugin/arcgrid/src/test/java/it/geosolutions/imageio/plugins/arcgrid/AsciiGridTest.java
+++ b/plugin/arcgrid/src/test/java/it/geosolutions/imageio/plugins/arcgrid/AsciiGridTest.java
@@ -23,7 +23,7 @@ import it.geosolutions.imageio.utilities.ImageIOUtilities;
 import it.geosolutions.resources.TestData;
 import junit.framework.Assert;
 import junit.framework.TestCase;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 import org.eclipse.imagen.media.imageread.ImageReadDescriptor;
@@ -105,7 +105,7 @@ public class AsciiGridTest extends TestCase {
      * Read an ArcGrid file and write it back to another file
      */
     public void testReadWrite() throws FileNotFoundException, IOException {
-        String title = new String("Simple JAI ImageRead operation test");
+        String title = new String("Simple ImageN ImageRead operation test");
         
         final String[] files = TestData.file(this,".").list(new FilenameFilter() {
 			
@@ -117,7 +117,7 @@ public class AsciiGridTest extends TestCase {
         for(String fileName:files){
 	        ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
 	        pbjImageRead.setParameter("Input", new File(inputDirectory,fileName));
-	        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+	        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 	        if (TestData.isInteractiveTest())
 	            ImageIOUtilities.visualize(image, title, true);
 	        else
@@ -126,7 +126,7 @@ public class AsciiGridTest extends TestCase {
             final File foutput = TestData.temp(this, "file.asc", true);
             AsciiGridsImageWriter writer = new AsciiGridsImageWriter(null);
             writer.setOutput(new FileImageOutputStream(foutput));
-            IIOMetadata metadata = (IIOMetadata) image.getProperty("JAI.ImageMetadata");
+            IIOMetadata metadata = (IIOMetadata) image.getProperty("ImageN.ImageMetadata");
             writer.write(new IIOImage(image, null, metadata));
 
 	        // //
@@ -136,7 +136,7 @@ public class AsciiGridTest extends TestCase {
 	        // //
 	        pbjImageRead = new ParameterBlockJAI("ImageRead");
 	        pbjImageRead.setParameter("Input", foutput);
-	        RenderedOp image2 = JAI.create("ImageRead", pbjImageRead);
+	        RenderedOp image2 = ImageN.create("ImageRead", pbjImageRead);
 	        title = new String("Read Back the just written image");
 	        if (TestData.isInteractiveTest())
 	            ImageIOUtilities.visualize(image, title, true);
@@ -153,12 +153,12 @@ public class AsciiGridTest extends TestCase {
      * Read an ESRI ArcGrid file and write it back as GRASS
      */
     public void testReadAsEsriAndWriteAsGrass() throws FileNotFoundException, IOException {
-        String title = new String("Simple JAI ImageRead operation test");
+        String title = new String("Simple ImageN ImageRead operation test");
 
         File testFile = TestData.file(this, "095b_dem_90m.asc");
         ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
         pbjImageRead.setParameter("Input", testFile);
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
         if (TestData.isInteractiveTest()) {
             ImageIOUtilities.visualize(image, title, true);
         } else {
@@ -191,7 +191,7 @@ public class AsciiGridTest extends TestCase {
         // //
         pbjImageRead = new ParameterBlockJAI("ImageRead");
         pbjImageRead.setParameter("Input", foutput);
-        RenderedOp image2 = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image2 = ImageN.create("ImageRead", pbjImageRead);
         title = new String("Read Back the just written image");
         if (TestData.isInteractiveTest()) {
             ImageIOUtilities.visualize(image2, title, true);
@@ -218,7 +218,7 @@ public class AsciiGridTest extends TestCase {
                     new FileInputStream(inputFile));
             ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
             pbjImageRead.setParameter("Input", stream);
-            RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+            RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
             if (TestData.isInteractiveTest())
                 ImageIOUtilities.visualize(image, title, true);
             else{
@@ -256,7 +256,7 @@ public class AsciiGridTest extends TestCase {
         // Setting subSampling factors
         irp.setSourceSubsampling(2, 2, 0, 0);
         pbjImageRead.setParameter("ReadParam", irp);
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
         if (TestData.isInteractiveTest())
             ImageIOUtilities.visualize(image, title, true);
         else{
@@ -314,7 +314,7 @@ public class AsciiGridTest extends TestCase {
         // Setting subSampling factors
         irp.setSourceSubsampling(4, 4, 0, 0);
         pbjImageRead.setParameter("ReadParam", irp);
-        image = JAI.create("ImageRead", pbjImageRead);
+        image = ImageN.create("ImageRead", pbjImageRead);
         if (TestData.isInteractiveTest())
             ImageIOUtilities.visualize(image, title, true);
         else{
@@ -369,7 +369,7 @@ public class AsciiGridTest extends TestCase {
         // Setting subSampling factors
         irp.setSourceSubsampling(4, 4, 0, 0);
         pbjImageRead.setParameter("ReadParam", irp);
-        image = JAI.create("ImageRead", pbjImageRead);
+        image = ImageN.create("ImageRead", pbjImageRead);
         if (TestData.isInteractiveTest())
             ImageIOUtilities.visualize(image, title, true);
         else{

--- a/plugin/arcgrid/src/test/java/it/geosolutions/imageio/plugins/arcgrid/raster/AsciiGridTileIndexRasterTest.java
+++ b/plugin/arcgrid/src/test/java/it/geosolutions/imageio/plugins/arcgrid/raster/AsciiGridTileIndexRasterTest.java
@@ -23,7 +23,7 @@ import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.stream.FileImageOutputStream;
 
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.PlanarImage;
 import org.eclipse.imagen.RenderedOp;
 
@@ -171,7 +171,7 @@ public class AsciiGridTileIndexRasterTest extends TestCase {
   public void outOfOrderTileAccess() throws Exception {
     // this test triggers the skipping routine and makes sure that it lands us in
     // the right position so that the first desired sample for the tile is read correctly
-    ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+    ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
     pbjImageRead.setParameter("Input", ascFile.getAbsolutePath());
     RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
@@ -191,7 +191,7 @@ public class AsciiGridTileIndexRasterTest extends TestCase {
 
   	public void outOfOrderTileAccessWithIndexedSkippedPositions() throws Exception {
     // this test confirms that the stream positions remembered during skipping are correct
-    ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+    ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
     pbjImageRead.setParameter("Input", ascFile.getAbsolutePath());
     RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
@@ -215,7 +215,7 @@ public class AsciiGridTileIndexRasterTest extends TestCase {
   }
 
   public void getExactMatchTileUsingIndexEntriesSetDuringReading() throws Exception {
-    ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+    ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
     pbjImageRead.setParameter("Input", ascFile.getAbsolutePath());
     RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
@@ -240,7 +240,7 @@ public class AsciiGridTileIndexRasterTest extends TestCase {
   }
 
   public void getTilesUsingIndexEntriesSetDuringReading() throws Exception {
-    ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+    ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
     pbjImageRead.setParameter("Input", ascFile.getAbsolutePath());
     RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
@@ -266,7 +266,7 @@ public class AsciiGridTileIndexRasterTest extends TestCase {
   }
 
   public void canWriteAndRead() throws Exception {
-    ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+    ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
     pbjImageRead.setParameter("Input", ascFile.getAbsolutePath());
     RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
     image.getTiles();

--- a/plugin/arcgrid/src/test/java/it/geosolutions/imageio/plugins/arcgrid/raster/AsciiGridTileIndexRasterTest.java
+++ b/plugin/arcgrid/src/test/java/it/geosolutions/imageio/plugins/arcgrid/raster/AsciiGridTileIndexRasterTest.java
@@ -22,7 +22,7 @@ import javax.imageio.ImageWriter;
 import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.stream.FileImageOutputStream;
 
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.PlanarImage;
 import org.eclipse.imagen.RenderedOp;
@@ -110,7 +110,7 @@ public class AsciiGridTileIndexRasterTest extends TestCase {
     pbjImageRead.add(null);
     pbjImageRead.add(readP);
     pbjImageRead.add(readerSPI.createReaderInstance());
-    final RenderedOp asciiCoverage = JAI.create("ImageRead", pbjImageRead, new RenderingHints(null));
+    final RenderedOp asciiCoverage = ImageN.create("ImageRead", pbjImageRead, new RenderingHints(null));
     return PlanarImage.wrapRenderedImage(asciiCoverage);
   }
 
@@ -173,7 +173,7 @@ public class AsciiGridTileIndexRasterTest extends TestCase {
     // the right position so that the first desired sample for the tile is read correctly
     ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
     pbjImageRead.setParameter("Input", ascFile.getAbsolutePath());
-    RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+    RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
     final int pixelsPerTile = image.getTileWidth() * image.getTileHeight();
     int pixel = (pixelsPerTile);
@@ -193,7 +193,7 @@ public class AsciiGridTileIndexRasterTest extends TestCase {
     // this test confirms that the stream positions remembered during skipping are correct
     ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
     pbjImageRead.setParameter("Input", ascFile.getAbsolutePath());
-    RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+    RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
     // this causes the second tile to be built without using any index
     // it used to be flakey and pointed the stream at the wrong position in the file
@@ -217,7 +217,7 @@ public class AsciiGridTileIndexRasterTest extends TestCase {
   public void getExactMatchTileUsingIndexEntriesSetDuringReading() throws Exception {
     ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
     pbjImageRead.setParameter("Input", ascFile.getAbsolutePath());
-    RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+    RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
     // this causes us to do throw away a lot of samples but put a whole bunch of entries in to the sample
     // stream index
@@ -242,7 +242,7 @@ public class AsciiGridTileIndexRasterTest extends TestCase {
   public void getTilesUsingIndexEntriesSetDuringReading() throws Exception {
     ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
     pbjImageRead.setParameter("Input", ascFile.getAbsolutePath());
-    RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+    RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
     // this causes us to do throw away a lot of samples but put a whole bunch of entries in to the sample
     // stream index
@@ -268,7 +268,7 @@ public class AsciiGridTileIndexRasterTest extends TestCase {
   public void canWriteAndRead() throws Exception {
     ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
     pbjImageRead.setParameter("Input", ascFile.getAbsolutePath());
-    RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+    RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
     image.getTiles();
 
     final int numPixels = width * height;
@@ -284,7 +284,7 @@ public class AsciiGridTileIndexRasterTest extends TestCase {
 
       AsciiGridsImageWriter writer = new AsciiGridsImageWriter(null);
       writer.setOutput(new FileImageOutputStream(foutput));
-      IIOMetadata metadata = (IIOMetadata) image.getProperty("JAI.ImageMetadata");
+      IIOMetadata metadata = (IIOMetadata) image.getProperty("ImageN.ImageMetadata");
       writer.write(new IIOImage(image, null, metadata));
 
 

--- a/plugin/cog/cog-reader/src/test/java/it/geosolutions/imageio/tiff/BandSelectionTest.java
+++ b/plugin/cog/cog-reader/src/test/java/it/geosolutions/imageio/tiff/BandSelectionTest.java
@@ -186,7 +186,7 @@ public class BandSelectionTest {
                 return reader.read(0, param);
             }
 
-            // deferred read, to go through the JAI machinery figuring out the deferred image layout 
+            // deferred read, to go through the ImageN machinery figuring out the deferred image layout 
             // (and then making it a BufferedImage so that we can dispose the reader safely)
             cogStream.init(param); // needed to make it load the header
             RenderedOp op = ImageReadDescriptor.create(cogStream, 0, false, false, false, null,

--- a/plugin/gdal/gdalarcbinarygrid/src/test/java/it/geosolutions/imageio/plugins/arcbinarygrid/ArcBinaryGridReadTest.java
+++ b/plugin/gdal/gdalarcbinarygrid/src/test/java/it/geosolutions/imageio/plugins/arcbinarygrid/ArcBinaryGridReadTest.java
@@ -29,7 +29,7 @@ import java.util.Iterator;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -37,7 +37,7 @@ import org.junit.Assert;
 
 /**
  * Testing reading capabilities for {@link ArcBinaryGridImageReader} leveraging
- * on JAI.
+ * on ImageN.
  * 
  * @author Simone Giannecchini, GeoSolutions.
  * @author Daniele Romagnoli, GeoSolutions.
@@ -61,7 +61,7 @@ public class ArcBinaryGridReadTest extends AbstractGDALTest {
         .append("\nTests are skipped");
 
     /**
-     * Simple test read through JAI - ImageIO
+     * Simple test read through ImageN - ImageIO
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -83,7 +83,7 @@ public class ArcBinaryGridReadTest extends AbstractGDALTest {
         rp.setSourceSubsampling(8, 8, 0, 0);
         pbjImageRead.setParameter("readParam", rp);
         pbjImageRead.setParameter("Input", file);
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
         if (TestData.isInteractiveTest())
             ImageIOUtilities.visualize(image, fileName, true);

--- a/plugin/gdal/gdalarcbinarygrid/src/test/java/it/geosolutions/imageio/plugins/arcbinarygrid/ArcBinaryGridReadTest.java
+++ b/plugin/gdal/gdalarcbinarygrid/src/test/java/it/geosolutions/imageio/plugins/arcbinarygrid/ArcBinaryGridReadTest.java
@@ -30,7 +30,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -70,7 +70,7 @@ public class ArcBinaryGridReadTest extends AbstractGDALTest {
         if (!isGDALAvailable) {
             return;
         }
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         File file = null;
         try {
             file = TestData.file(this, fileName);
@@ -78,7 +78,7 @@ public class ArcBinaryGridReadTest extends AbstractGDALTest {
             LOGGER.warning(warningMessage.toString());
             return;
         }
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         ImageReadParam rp = new ImageReadParam();
         rp.setSourceSubsampling(8, 8, 0, 0);
         pbjImageRead.setParameter("readParam", rp);

--- a/plugin/gdal/gdalarcgrid/src/test/java/it/geosolutions/imageio/plugins/arcgrid/ArcGridReadTest.java
+++ b/plugin/gdal/gdalarcgrid/src/test/java/it/geosolutions/imageio/plugins/arcgrid/ArcGridReadTest.java
@@ -32,7 +32,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -62,11 +62,11 @@ public class ArcGridReadTest extends AbstractGDALTest {
 		if (!isGDALAvailable) {
 			return;
 		}
-		final ParameterBlockJAI pbjImageRead;
+		final ParameterBlockImageN pbjImageRead;
 		final String fileName = "095b_dem_90m.asc";
 		TestData.unzipFile(this, "arcgrid.zip");
 		final File file = TestData.file(this, fileName);
-		pbjImageRead = new ParameterBlockJAI("ImageRead");
+		pbjImageRead = new ParameterBlockImageN("ImageRead");
 		pbjImageRead.setParameter("Input", file);
 		RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 		if (TestData.isInteractiveTest())

--- a/plugin/gdal/gdalarcgrid/src/test/java/it/geosolutions/imageio/plugins/arcgrid/ArcGridReadTest.java
+++ b/plugin/gdal/gdalarcgrid/src/test/java/it/geosolutions/imageio/plugins/arcgrid/ArcGridReadTest.java
@@ -31,7 +31,7 @@ import java.util.Iterator;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -40,7 +40,7 @@ import org.junit.Test;
 
 /**
  * Testing reading capabilities for {@link ArcGridImageReader} leveraging on
- * JAI.
+ * ImageN.
  * 
  * @author Simone Giannecchini, GeoSolutions.
  * @author Daniele Romagnoli, GeoSolutions.
@@ -52,7 +52,7 @@ public class ArcGridReadTest extends AbstractGDALTest {
 	}
 
 	/**
-	 * Simple test read through JAI - ImageIO
+	 * Simple test read through ImageN - ImageIO
 	 * 
 	 * @throws FileNotFoundException
 	 * @throws IOException
@@ -68,7 +68,7 @@ public class ArcGridReadTest extends AbstractGDALTest {
 		final File file = TestData.file(this, fileName);
 		pbjImageRead = new ParameterBlockJAI("ImageRead");
 		pbjImageRead.setParameter("Input", file);
-		RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+		RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 		if (TestData.isInteractiveTest())
 			Viewer.visualizeAllInformation(image, fileName);
 		else

--- a/plugin/gdal/gdalbsb/src/test/java/it/geosolutions/imageio/plugins/bsb/BSBTest.java
+++ b/plugin/gdal/gdalbsb/src/test/java/it/geosolutions/imageio/plugins/bsb/BSBTest.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -69,10 +69,10 @@ public class BSBTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
 

--- a/plugin/gdal/gdalbsb/src/test/java/it/geosolutions/imageio/plugins/bsb/BSBTest.java
+++ b/plugin/gdal/gdalbsb/src/test/java/it/geosolutions/imageio/plugins/bsb/BSBTest.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -49,7 +49,7 @@ public class BSBTest extends AbstractGDALTest {
     }
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -80,7 +80,7 @@ public class BSBTest extends AbstractGDALTest {
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(32).setTileWidth(32);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
         if (TestData.isInteractiveTest()) {
             ImageIOUtilities.visualize(image, "test", true);

--- a/plugin/gdal/gdaldoq1/src/test/java/it/geosolutions/imageio/plugins/doq1/DOQ1Test.java
+++ b/plugin/gdal/gdaldoq1/src/test/java/it/geosolutions/imageio/plugins/doq1/DOQ1Test.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -67,10 +67,10 @@ public class DOQ1Test extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
         

--- a/plugin/gdal/gdaldoq1/src/test/java/it/geosolutions/imageio/plugins/doq1/DOQ1Test.java
+++ b/plugin/gdal/gdaldoq1/src/test/java/it/geosolutions/imageio/plugins/doq1/DOQ1Test.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -47,7 +47,7 @@ public class DOQ1Test extends AbstractGDALTest {
     public final static String fileName = "fakedoq1.doq";
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -83,7 +83,7 @@ public class DOQ1Test extends AbstractGDALTest {
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(32).setTileWidth(32);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
         if (TestData.isInteractiveTest()) {
             Viewer.visualizeAllInformation(image, "test");

--- a/plugin/gdal/gdaldoq2/src/test/java/it/geosolutions/imageio/plugins/doq2/DOQ2Test.java
+++ b/plugin/gdal/gdaldoq2/src/test/java/it/geosolutions/imageio/plugins/doq2/DOQ2Test.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -74,10 +74,10 @@ public class DOQ2Test extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
 

--- a/plugin/gdal/gdaldoq2/src/test/java/it/geosolutions/imageio/plugins/doq2/DOQ2Test.java
+++ b/plugin/gdal/gdaldoq2/src/test/java/it/geosolutions/imageio/plugins/doq2/DOQ2Test.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -54,7 +54,7 @@ public class DOQ2Test extends AbstractGDALTest {
     }
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -90,7 +90,7 @@ public class DOQ2Test extends AbstractGDALTest {
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
         if (TestData.isInteractiveTest()) {
             Viewer.visualizeAllInformation(image, "test");

--- a/plugin/gdal/gdaldted/src/test/java/it/geosolutions/imageio/plugins/dted/DTEDTest.java
+++ b/plugin/gdal/gdaldted/src/test/java/it/geosolutions/imageio/plugins/dted/DTEDTest.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/plugin/gdal/gdaldted/src/test/java/it/geosolutions/imageio/plugins/dted/DTEDTest.java
+++ b/plugin/gdal/gdaldted/src/test/java/it/geosolutions/imageio/plugins/dted/DTEDTest.java
@@ -49,7 +49,7 @@ public class DTEDTest extends AbstractGDALTest {
     }
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException

--- a/plugin/gdal/gdalecw/src/test/java/it/geosolutions/imageio/plugins/ecw/ECWTest.java
+++ b/plugin/gdal/gdalecw/src/test/java/it/geosolutions/imageio/plugins/ecw/ECWTest.java
@@ -34,7 +34,7 @@ import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -79,13 +79,13 @@ public class ECWTest extends AbstractGDALTest {
     public void imageRead() throws FileNotFoundException, IOException {
     	if(!isECWAvailable)
     		return;
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final EnhancedImageReadParam irp = new EnhancedImageReadParam();
         final String fileName = "sample.ecw";
         final File file = TestData.file(this, fileName);
 
         irp.setSourceSubsampling(2, 2, 0, 0);
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
         final ImageLayout l = new ImageLayout();

--- a/plugin/gdal/gdalecw/src/test/java/it/geosolutions/imageio/plugins/ecw/ECWTest.java
+++ b/plugin/gdal/gdalecw/src/test/java/it/geosolutions/imageio/plugins/ecw/ECWTest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -90,8 +90,8 @@ public class ECWTest extends AbstractGDALTest {
         pbjImageRead.setParameter("readParam", irp);
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
         if (TestData.isInteractiveTest())
         	Viewer.visualizeAllInformation(image, fileName);
         else
@@ -172,13 +172,13 @@ public class ECWTest extends AbstractGDALTest {
     public void setUp() throws Exception {
         super.setUp();
         // general settings
-        JAI.getDefaultInstance().getTileScheduler().setParallelism(10);
-        JAI.getDefaultInstance().getTileScheduler().setPriority(4);
-        JAI.getDefaultInstance().getTileScheduler().setPrefetchPriority(2);
-        JAI.getDefaultInstance().getTileScheduler().setPrefetchParallelism(5);
-        JAI.getDefaultInstance().getTileCache().setMemoryCapacity(
+        ImageN.getDefaultInstance().getTileScheduler().setParallelism(10);
+        ImageN.getDefaultInstance().getTileScheduler().setPriority(4);
+        ImageN.getDefaultInstance().getTileScheduler().setPrefetchPriority(2);
+        ImageN.getDefaultInstance().getTileScheduler().setPrefetchParallelism(5);
+        ImageN.getDefaultInstance().getTileCache().setMemoryCapacity(
                 128 * 1024 * 1024);
-        JAI.getDefaultInstance().getTileCache().setMemoryThreshold(1.0f);
+        ImageN.getDefaultInstance().getTileCache().setMemoryThreshold(1.0f);
     }
 
 

--- a/plugin/gdal/gdalecwjp2/src/test/java/it/geosolutions/imageio/plugins/jp2ecw/JP2KReadTest.java
+++ b/plugin/gdal/gdalecwjp2/src/test/java/it/geosolutions/imageio/plugins/jp2ecw/JP2KReadTest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -40,7 +40,7 @@ import org.junit.Before;
 
 /**
  * Testing reading capabilities for {@link JP2GDALEcwImageReader} leveraging on
- * JAI.
+ * ImageN.
  * 
  * @author Daniele Romagnoli, GeoSolutions.
  * @author Simone Giannecchini, GeoSolutions.
@@ -95,8 +95,8 @@ public class JP2KReadTest extends AbstractGDALTest {
         final ImageLayout layout = new ImageLayout();
         layout.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(256)
                 .setTileWidth(256);
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, layout));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, layout));
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image,"gdaljp2k");
         else
@@ -105,7 +105,7 @@ public class JP2KReadTest extends AbstractGDALTest {
     }
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -140,8 +140,8 @@ public class JP2KReadTest extends AbstractGDALTest {
         final ImageLayout layout = new ImageLayout();
         layout.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(256)
                 .setTileWidth(256);
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, layout));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, layout));
 
         if (TestData.isInteractiveTest())
             ImageIOUtilities.visualize(image, "subsampled");
@@ -161,7 +161,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         pbjCrop.setParameter("y", yCrop);
         pbjCrop.setParameter("width", cropWidth);
         pbjCrop.setParameter("height", cropHeigth);
-        final RenderedOp croppedImage = JAI.create("Crop", pbjCrop);
+        final RenderedOp croppedImage = ImageN.create("Crop", pbjCrop);
 
         if (TestData.isInteractiveTest())
             ImageIOUtilities.visualize(croppedImage, "cropped");
@@ -176,7 +176,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         Float yTrans = new Float(yCrop.floatValue() * (-1));
         pbjTranslate.setParameter("xTrans", xTrans);
         pbjTranslate.setParameter("yTrans", yTrans);
-        final RenderedOp translatedImage = JAI
+        final RenderedOp translatedImage = ImageN
                 .create("Translate", pbjTranslate);
 
         if (TestData.isInteractiveTest())
@@ -196,7 +196,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         pbjRotate.setParameter("yOrigin", yOrigin);
         pbjRotate.setParameter("angle", angle);
 
-        final RenderedOp rotatedImage = JAI.create("Rotate", pbjRotate);
+        final RenderedOp rotatedImage = ImageN.create("Rotate", pbjRotate);
 
         StringBuilder title = new StringBuilder("SUBSAMP:").append("X[").append(
                 xSubSampling.toString()).append("]-Y[").append(
@@ -221,8 +221,8 @@ public class JP2KReadTest extends AbstractGDALTest {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        JAI.getDefaultInstance().getTileCache().setMemoryCapacity(64 * 1024 * 1024);
-        JAI.getDefaultInstance().getTileCache().setMemoryThreshold(1.0f);
+        ImageN.getDefaultInstance().getTileCache().setMemoryCapacity(64 * 1024 * 1024);
+        ImageN.getDefaultInstance().getTileCache().setMemoryThreshold(1.0f);
     }
 
 }

--- a/plugin/gdal/gdalecwjp2/src/test/java/it/geosolutions/imageio/plugins/jp2ecw/JP2KReadTest.java
+++ b/plugin/gdal/gdalecwjp2/src/test/java/it/geosolutions/imageio/plugins/jp2ecw/JP2KReadTest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.gdal.gdal.Driver;
@@ -86,9 +86,9 @@ public class JP2KReadTest extends AbstractGDALTest {
         if (!isJP2ECWAvailable) {
             return;
         }
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final File file = TestData.file(this, fileName);
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("Reader", new JP2GDALEcwImageReaderSpi()
                 .createReaderInstance());
@@ -120,7 +120,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
         Integer xSubSampling = new Integer(2);
@@ -132,7 +132,7 @@ public class JP2KReadTest extends AbstractGDALTest {
                 .intValue(), xSubSamplingOffset.intValue(), ySubSamplingOffset
                 .intValue());
 
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", inputFile);
         pbjImageRead.setParameter("readParam", irp);
         pbjImageRead.setParameter("Reader", new JP2GDALEcwImageReaderSpi()
@@ -149,7 +149,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to crop
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjCrop = new ParameterBlockJAI("Crop");
+        final ParameterBlockImageN pbjCrop = new ParameterBlockImageN("Crop");
         pbjCrop.addSource(image);
 
         // Setting a square crop to avoid blanks zone when rotating.
@@ -169,7 +169,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to translate
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjTranslate = new ParameterBlockJAI(
+        final ParameterBlockImageN pbjTranslate = new ParameterBlockImageN(
                 "Translate");
         pbjTranslate.addSource(croppedImage);
         Float xTrans = new Float(xCrop.floatValue() * (-1));
@@ -185,7 +185,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to rotate
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjRotate = new ParameterBlockJAI("Rotate");
+        final ParameterBlockImageN pbjRotate = new ParameterBlockImageN("Rotate");
         pbjRotate.addSource(translatedImage);
 
         Float xOrigin = new Float(cropWidth.floatValue() / 2);

--- a/plugin/gdal/gdalenvisat/src/test/java/it/geosolutions/imageio/plugins/envisat/EnvisatTest.java
+++ b/plugin/gdal/gdalenvisat/src/test/java/it/geosolutions/imageio/plugins/envisat/EnvisatTest.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Test;
@@ -65,7 +65,7 @@ public class EnvisatTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
         // subsample by 2 on both dimensions
@@ -74,7 +74,7 @@ public class EnvisatTest extends AbstractGDALTest {
         final int xSubSamplingOffset = 0;
         final int ySubSamplingOffset = 0;
         irp.setSourceSubsampling(xSubSampling, ySubSampling,xSubSamplingOffset, ySubSamplingOffset);
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
 

--- a/plugin/gdal/gdalenvisat/src/test/java/it/geosolutions/imageio/plugins/envisat/EnvisatTest.java
+++ b/plugin/gdal/gdalenvisat/src/test/java/it/geosolutions/imageio/plugins/envisat/EnvisatTest.java
@@ -25,7 +25,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import javax.imageio.ImageReadParam;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -44,7 +44,7 @@ public class EnvisatTest extends AbstractGDALTest {
 
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -79,7 +79,7 @@ public class EnvisatTest extends AbstractGDALTest {
         pbjImageRead.setParameter("readParam", irp);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image, "Subsampling Read");

--- a/plugin/gdal/gdalerdasimg/src/test/java/it/geosolutions/imageio/plugins/erdasimg/ErdasImgTest.java
+++ b/plugin/gdal/gdalerdasimg/src/test/java/it/geosolutions/imageio/plugins/erdasimg/ErdasImgTest.java
@@ -25,7 +25,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -44,7 +44,7 @@ public class ErdasImgTest extends AbstractGDALTest {
 
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -71,7 +71,7 @@ public class ErdasImgTest extends AbstractGDALTest {
         pbjImageRead.setParameter("Input", file);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image, "Read");

--- a/plugin/gdal/gdalerdasimg/src/test/java/it/geosolutions/imageio/plugins/erdasimg/ErdasImgTest.java
+++ b/plugin/gdal/gdalerdasimg/src/test/java/it/geosolutions/imageio/plugins/erdasimg/ErdasImgTest.java
@@ -26,7 +26,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -66,8 +66,8 @@ public class ErdasImgTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        final ParameterBlockImageN pbjImageRead;
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
 
         // get a RenderedImage

--- a/plugin/gdal/gdalgeotiff/src/test/java/it/geosolutions/imageio/plugins/geotiff/GeoTiffTest.java
+++ b/plugin/gdal/gdalgeotiff/src/test/java/it/geosolutions/imageio/plugins/geotiff/GeoTiffTest.java
@@ -45,7 +45,7 @@ import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.stream.FileImageOutputStream;
 
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -138,7 +138,7 @@ public class GeoTiffTest extends AbstractGDALTest {
         pbjImageRead = new ParameterBlockJAI("ImageRead");
         pbjImageRead.setParameter("Input", new FileImageInputStreamExtImpl(file));
         pbjImageRead.setParameter("Reader", new GeoTiffImageReaderSpi().createReaderInstance());
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image, "", true);
         else
@@ -175,7 +175,7 @@ public class GeoTiffTest extends AbstractGDALTest {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(256).setTileWidth(256);
 
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image,"geotiff");
@@ -193,7 +193,7 @@ public class GeoTiffTest extends AbstractGDALTest {
         final ParameterBlockJAI pbjImageReRead = new ParameterBlockJAI("ImageRead");
         pbjImageReRead.setParameter("Input", outputFile);
         pbjImageReRead.setParameter("Reader", new GeoTiffImageReaderSpi() .createReaderInstance());
-        final RenderedOp image2 = JAI.create("ImageRead", pbjImageReRead);
+        final RenderedOp image2 = ImageN.create("ImageRead", pbjImageReRead);
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image2,"geotif2");
         else
@@ -226,7 +226,7 @@ public class GeoTiffTest extends AbstractGDALTest {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(256).setTileWidth(256);
 
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead, new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead, new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image, "Paletted image read");
@@ -244,7 +244,7 @@ public class GeoTiffTest extends AbstractGDALTest {
         final ParameterBlockJAI pbjImageReRead = new ParameterBlockJAI("ImageRead");
         pbjImageReRead.setParameter("Input", outputFile);
         pbjImageReRead.setParameter("Reader", new GeoTiffImageReaderSpi().createReaderInstance());
-        final RenderedOp image2 = JAI.create("ImageRead", pbjImageReRead);
+        final RenderedOp image2 = ImageN.create("ImageRead", pbjImageReRead);
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image2,"Paletted image read back after writing");
         else

--- a/plugin/gdal/gdalgeotiff/src/test/java/it/geosolutions/imageio/plugins/geotiff/GeoTiffTest.java
+++ b/plugin/gdal/gdalgeotiff/src/test/java/it/geosolutions/imageio/plugins/geotiff/GeoTiffTest.java
@@ -46,7 +46,7 @@ import javax.imageio.stream.FileImageOutputStream;
 
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.gdal.gdal.gdal;
@@ -131,11 +131,11 @@ public class GeoTiffTest extends AbstractGDALTest {
         if (!isGDALAvailable) {
             return;
         }
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         String fileName = "utmByte.tif";
         final File file = TestData.file(this, fileName);
 
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", new FileImageInputStreamExtImpl(file));
         pbjImageRead.setParameter("Reader", new GeoTiffImageReaderSpi().createReaderInstance());
         RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
@@ -167,7 +167,7 @@ public class GeoTiffTest extends AbstractGDALTest {
         reader.setInput(inputFile);
         final IIOMetadata metadata = reader.getImageMetadata(0);
 
-        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", inputFile);
         pbjImageRead.setParameter("reader", reader);
         pbjImageRead.setParameter("readParam", rparam);
@@ -190,7 +190,7 @@ public class GeoTiffTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read again
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageReRead = new ParameterBlockJAI("ImageRead");
+        final ParameterBlockImageN pbjImageReRead = new ParameterBlockImageN("ImageRead");
         pbjImageReRead.setParameter("Input", outputFile);
         pbjImageReRead.setParameter("Reader", new GeoTiffImageReaderSpi() .createReaderInstance());
         final RenderedOp image2 = ImageN.create("ImageRead", pbjImageReRead);
@@ -219,7 +219,7 @@ public class GeoTiffTest extends AbstractGDALTest {
         reader.setInput(inputFile);
         final IIOMetadata metadata = reader.getImageMetadata(0);
 
-        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", inputFile);
         pbjImageRead.setParameter("reader", reader);
 
@@ -241,7 +241,7 @@ public class GeoTiffTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read again
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageReRead = new ParameterBlockJAI("ImageRead");
+        final ParameterBlockImageN pbjImageReRead = new ParameterBlockImageN("ImageRead");
         pbjImageReRead.setParameter("Input", outputFile);
         pbjImageReRead.setParameter("Reader", new GeoTiffImageReaderSpi().createReaderInstance());
         final RenderedOp image2 = ImageN.create("ImageRead", pbjImageReRead);

--- a/plugin/gdal/gdalhdf4/src/test/java/it/geosolutions/imageio/plugins/hdf4/HDF4Test.java
+++ b/plugin/gdal/gdalhdf4/src/test/java/it/geosolutions/imageio/plugins/hdf4/HDF4Test.java
@@ -34,7 +34,7 @@ import javax.imageio.ImageReader;
 import javax.imageio.ImageTypeSpecifier;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -78,7 +78,7 @@ public class HDF4Test extends AbstractGDALTest {
                 irp.setSourceSubsampling(1, 1, 0, 0);
                 final String fileName = "TOVS_DAILY_AM_870330_NG.HDF";
                 final File file = TestData.file(this, fileName);
-                ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+                ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
                         "ImageRead");
                 final ImageReader mReader = new HDF4ImageReaderSpi()
                         .createReaderInstance();

--- a/plugin/gdal/gdalhdf4/src/test/java/it/geosolutions/imageio/plugins/hdf4/HDF4Test.java
+++ b/plugin/gdal/gdalhdf4/src/test/java/it/geosolutions/imageio/plugins/hdf4/HDF4Test.java
@@ -33,7 +33,7 @@ import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import javax.imageio.ImageTypeSpecifier;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -90,8 +90,8 @@ public class HDF4Test extends AbstractGDALTest {
                 l.setTileGridXOffset(0).setTileGridYOffset(0)
                         .setTileHeight(256).setTileWidth(256);
                 // get a RenderedImage
-                RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                        new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+                RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                        new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
                 image.getTiles();
                 if (TestData.isInteractiveTest())
                     Viewer.visualizeAllInformation(image, fileName);
@@ -206,12 +206,12 @@ public class HDF4Test extends AbstractGDALTest {
 	        return;
 	    }
 	    // general settings
-	    JAI.getDefaultInstance().getTileScheduler().setParallelism(5);
-	    JAI.getDefaultInstance().getTileScheduler().setPriority(4);
-	    JAI.getDefaultInstance().getTileScheduler().setPrefetchPriority(2);
-	    JAI.getDefaultInstance().getTileScheduler().setPrefetchParallelism(5);
-	    JAI.getDefaultInstance().getTileCache().setMemoryCapacity(
+	    ImageN.getDefaultInstance().getTileScheduler().setParallelism(5);
+	    ImageN.getDefaultInstance().getTileScheduler().setPriority(4);
+	    ImageN.getDefaultInstance().getTileScheduler().setPrefetchPriority(2);
+	    ImageN.getDefaultInstance().getTileScheduler().setPrefetchParallelism(5);
+	    ImageN.getDefaultInstance().getTileCache().setMemoryCapacity(
 	            180 * 1024 * 1024);
-	    JAI.getDefaultInstance().getTileCache().setMemoryThreshold(1.0f);
+	    ImageN.getDefaultInstance().getTileCache().setMemoryThreshold(1.0f);
 	}
 }

--- a/plugin/gdal/gdalidrisi/src/test/java/it/geosolutions/imageio/plugins/idrisi/IdrisiReadTest.java
+++ b/plugin/gdal/gdalidrisi/src/test/java/it/geosolutions/imageio/plugins/idrisi/IdrisiReadTest.java
@@ -32,7 +32,7 @@ import java.util.Iterator;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -41,7 +41,7 @@ import org.junit.Test;
 
 /**
  * Testing reading capabilities for {@link IDRISIImageReader} leveraging on
- * JAI.
+ * ImageN.
  * 
  * @author Simone Giannecchini, GeoSolutions.
  * @author Daniele Romagnoli, GeoSolutions.
@@ -53,7 +53,7 @@ public class IdrisiReadTest extends AbstractGDALTest {
 	}
 
 	/**
-	 * Simple test read through JAI - ImageIO
+	 * Simple test read through ImageN - ImageIO
 	 * 
 	 * @throws FileNotFoundException
 	 * @throws IOException
@@ -69,7 +69,7 @@ public class IdrisiReadTest extends AbstractGDALTest {
 		final File file = TestData.file(this, fileName);
 		pbjImageRead = new ParameterBlockJAI("ImageRead");
 		pbjImageRead.setParameter("Input", file);
-		RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+		RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 		if (TestData.isInteractiveTest())
 			Viewer.visualizeAllInformation(image, fileName);
 		else

--- a/plugin/gdal/gdalidrisi/src/test/java/it/geosolutions/imageio/plugins/idrisi/IdrisiReadTest.java
+++ b/plugin/gdal/gdalidrisi/src/test/java/it/geosolutions/imageio/plugins/idrisi/IdrisiReadTest.java
@@ -33,7 +33,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -63,11 +63,11 @@ public class IdrisiReadTest extends AbstractGDALTest {
 		if (!isGDALAvailable) {
 			return;
 		}
-		final ParameterBlockJAI pbjImageRead;
+		final ParameterBlockImageN pbjImageRead;
 		final String fileName = "idrisi.rst";
 		TestData.unzipFile(this, "idrisi.zip");
 		final File file = TestData.file(this, fileName);
-		pbjImageRead = new ParameterBlockJAI("ImageRead");
+		pbjImageRead = new ParameterBlockImageN("ImageRead");
 		pbjImageRead.setParameter("Input", file);
 		RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 		if (TestData.isInteractiveTest())

--- a/plugin/gdal/gdaljpeg/src/test/java/it/geosolutions/imageio/plugins/jpeg/JPEGReadTest.java
+++ b/plugin/gdal/gdaljpeg/src/test/java/it/geosolutions/imageio/plugins/jpeg/JPEGReadTest.java
@@ -37,7 +37,7 @@ import javax.imageio.ImageReader;
 import javax.imageio.ImageTypeSpecifier;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -65,12 +65,12 @@ public class JPEGReadTest extends AbstractGDALTest {
         if (!isGDALAvailable) {
             return;
         }
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
         final String fileName = "bw_sample.jpg";
         final File file = TestData.file(this, fileName);
         irp.setSourceSubsampling(1, 2, 0, 0);
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("Reader", new JpegGDALImageReaderSpi()
                 .createReaderInstance());
@@ -156,7 +156,7 @@ public class JPEGReadTest extends AbstractGDALTest {
         // //
         ImageReader reader = new JpegGDALImageReaderSpi()
                 .createReaderInstance();
-        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
                 "ImageRead");
         pbjImageRead.setParameter("Input", inputFile);
         pbjImageRead.setParameter("reader", reader);

--- a/plugin/gdal/gdaljpeg/src/test/java/it/geosolutions/imageio/plugins/jpeg/JPEGReadTest.java
+++ b/plugin/gdal/gdaljpeg/src/test/java/it/geosolutions/imageio/plugins/jpeg/JPEGReadTest.java
@@ -36,7 +36,7 @@ import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import javax.imageio.ImageTypeSpecifier;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -47,7 +47,7 @@ import org.eclipse.imagen.RasterFactory;
 
 /**
  * Testing reading capabilities for {@link JpegGDALImageReader} leveraging on
- * JAI.
+ * ImageN.
  * 
  * @author Daniele Romagnoli, GeoSolutions.
  * @author Simone Giannecchini, GeoSolutions.
@@ -80,8 +80,8 @@ public class JPEGReadTest extends AbstractGDALTest {
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512)
                 .setTileWidth(512);
 
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image,fileName);
         else
@@ -165,8 +165,8 @@ public class JPEGReadTest extends AbstractGDALTest {
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(128)
                 .setTileWidth(128);
 
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image,"imageread");

--- a/plugin/gdal/gdalkakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2kakadu/JP2KReadTest.java
+++ b/plugin/gdal/gdalkakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2kakadu/JP2KReadTest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -58,11 +58,11 @@ public class JP2KReadTest extends AbstractJP2KTestCase {
             return;
         }
 
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final File file = TestData.file(this, fileName);
         JP2GDALKakaduImageReaderSpi
                 .setKakaduInputErrorManagement(KakaduErrorManagementType.FAST);
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
                 .createReaderInstance());
@@ -97,7 +97,7 @@ public class JP2KReadTest extends AbstractJP2KTestCase {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
         Integer xSubSampling = new Integer(2);
@@ -109,7 +109,7 @@ public class JP2KReadTest extends AbstractJP2KTestCase {
                 .intValue(), xSubSamplingOffset.intValue(), ySubSamplingOffset
                 .intValue());
 
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", inputFile);
         pbjImageRead.setParameter("readParam", irp);
         pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
@@ -127,7 +127,7 @@ public class JP2KReadTest extends AbstractJP2KTestCase {
         // ////////////////////////////////////////////////////////////////
         // preparing to crop
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjCrop = new ParameterBlockJAI("Crop");
+        final ParameterBlockImageN pbjCrop = new ParameterBlockImageN("Crop");
         pbjCrop.addSource(image);
 
         // Setting a square crop to avoid blanks zone when rotating.
@@ -147,7 +147,7 @@ public class JP2KReadTest extends AbstractJP2KTestCase {
         // ////////////////////////////////////////////////////////////////
         // preparing to translate
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjTranslate = new ParameterBlockJAI(
+        final ParameterBlockImageN pbjTranslate = new ParameterBlockImageN(
                 "Translate");
         pbjTranslate.addSource(croppedImage);
         Float xTrans = new Float(xCrop.floatValue() * (-1));
@@ -163,7 +163,7 @@ public class JP2KReadTest extends AbstractJP2KTestCase {
         // ////////////////////////////////////////////////////////////////
         // preparing to rotate
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjRotate = new ParameterBlockJAI("Rotate");
+        final ParameterBlockImageN pbjRotate = new ParameterBlockImageN("Rotate");
         pbjRotate.addSource(translatedImage);
 
         Float xOrigin = new Float(cropWidth.floatValue() / 2);

--- a/plugin/gdal/gdalkakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2kakadu/JP2KReadTest.java
+++ b/plugin/gdal/gdalkakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2kakadu/JP2KReadTest.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -37,7 +37,7 @@ import org.junit.Test;
 
 /**
  * Testing reading capabilities for {@link JP2GDALKakaduImageReader} leveraging
- * on JAI.
+ * on ImageN.
  * 
  * @author Daniele Romagnoli, GeoSolutions.
  * @author Simone Giannecchini, GeoSolutions.
@@ -69,8 +69,8 @@ public class JP2KReadTest extends AbstractJP2KTestCase {
         final ImageLayout layout = new ImageLayout();
         layout.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(256)
                 .setTileWidth(256);
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, layout));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, layout));
         if (TestData.isInteractiveTest())
             Viewer.visualizeBothMetadata(image, "");
         else
@@ -79,7 +79,7 @@ public class JP2KReadTest extends AbstractJP2KTestCase {
     }
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -118,8 +118,8 @@ public class JP2KReadTest extends AbstractJP2KTestCase {
         final ImageLayout layout = new ImageLayout();
         layout.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512)
                 .setTileWidth(512);
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, layout));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, layout));
 
         if (TestData.isInteractiveTest())
             ImageIOUtilities.visualize(image, "subsampled");
@@ -139,7 +139,7 @@ public class JP2KReadTest extends AbstractJP2KTestCase {
         pbjCrop.setParameter("y", yCrop);
         pbjCrop.setParameter("width", cropWidth);
         pbjCrop.setParameter("height", cropHeigth);
-        final RenderedOp croppedImage = JAI.create("Crop", pbjCrop);
+        final RenderedOp croppedImage = ImageN.create("Crop", pbjCrop);
 
         if (TestData.isInteractiveTest())
             ImageIOUtilities.visualize(croppedImage, "cropped");
@@ -154,7 +154,7 @@ public class JP2KReadTest extends AbstractJP2KTestCase {
         Float yTrans = new Float(yCrop.floatValue() * (-1));
         pbjTranslate.setParameter("xTrans", xTrans);
         pbjTranslate.setParameter("yTrans", yTrans);
-        final RenderedOp translatedImage = JAI
+        final RenderedOp translatedImage = ImageN
                 .create("Translate", pbjTranslate);
 
         if (TestData.isInteractiveTest())
@@ -174,7 +174,7 @@ public class JP2KReadTest extends AbstractJP2KTestCase {
         pbjRotate.setParameter("yOrigin", yOrigin);
         pbjRotate.setParameter("angle", angle);
 
-        final RenderedOp rotatedImage = JAI.create("Rotate", pbjRotate);
+        final RenderedOp rotatedImage = ImageN.create("Rotate", pbjRotate);
 
         StringBuffer title = new StringBuffer("SUBSAMP:").append("X[").append(
                 xSubSampling.toString()).append("]-Y[").append(

--- a/plugin/gdal/gdalkakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2kakadu/JP2KWriteTest.java
+++ b/plugin/gdal/gdalkakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2kakadu/JP2KWriteTest.java
@@ -84,7 +84,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -104,7 +104,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -129,7 +129,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -183,7 +183,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -202,7 +202,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -227,7 +227,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -275,7 +275,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -293,7 +293,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -319,7 +319,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -368,7 +368,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -386,7 +386,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -411,7 +411,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -436,7 +436,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite3 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite3 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite3.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile3));
@@ -482,7 +482,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -500,7 +500,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -525,7 +525,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -564,7 +564,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -598,7 +598,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //                    deleteTempFilesOnExit);
 //
 //            // Setting output and writer
-//            final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//            final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                    "ImageWrite");
 //            pbjImageWrite.setParameter("Output",
 //                    new FileImageOutputStreamExtImpl(outputFile));
@@ -646,7 +646,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -664,7 +664,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -689,7 +689,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -735,7 +735,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -753,7 +753,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -778,7 +778,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -824,7 +824,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -842,7 +842,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -867,7 +867,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -907,7 +907,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //
 //        pbjImageRead.setParameter("Input", inputFile);
@@ -942,7 +942,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //                    deleteTempFilesOnExit);
 //
 //            // Setting output and writer
-//            final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//            final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                    "ImageWrite");
 //            pbjImageWrite.setParameter("Output",
 //                    new FileImageOutputStreamExtImpl(outputFile));
@@ -997,7 +997,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -1015,7 +1015,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -1040,7 +1040,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -1105,7 +1105,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -1123,7 +1123,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -1167,7 +1167,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -1185,7 +1185,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -1210,7 +1210,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -1255,7 +1255,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -1273,7 +1273,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -1298,7 +1298,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -1350,7 +1350,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -1369,7 +1369,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -1395,7 +1395,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -1442,7 +1442,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //
 //        pbjImageRead.setParameter("Input", inputFile);
@@ -1461,7 +1461,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -1486,7 +1486,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // ////////////////////////////////////////////////////////////////////
 //
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -1537,7 +1537,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -1555,7 +1555,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -1580,7 +1580,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -1635,7 +1635,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -1653,7 +1653,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -1678,7 +1678,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -1703,7 +1703,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite3 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite3 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite3.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile3));
@@ -1756,7 +1756,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -1774,7 +1774,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -1799,7 +1799,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -1845,7 +1845,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // //
 //        // Preparing to read
 //        // //
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
@@ -1863,7 +1863,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile1));
@@ -1888,7 +1888,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite2 = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite2 = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite2.setParameter("Output", new FileImageOutputStreamExtImpl(
 //                outputFile2));
@@ -1928,7 +1928,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // Reading
 //        //
 //        // ////////////////////////////////////////////////////////////////////
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        ImageReader reader = new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance();
@@ -1949,7 +1949,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        //
 //        // ////////////////////////////////////////////////////////////////////
 //        // Setting output and writer
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
 //                "ImageWrite");
 //        pbjImageWrite.setParameter("Output", outputFile);
 //
@@ -1976,7 +1976,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // preparing to read again
 //        //
 //        // ////////////////////////////////////////////////////////////////
-//        final ParameterBlockJAI pbjImageReRead = new ParameterBlockJAI(
+//        final ParameterBlockImageN pbjImageReRead = new ParameterBlockImageN(
 //                "ImageRead");
 //        pbjImageReRead.setParameter("Input", outputFile);
 //        pbjImageReRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
@@ -1992,7 +1992,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 
 //    /** Reads the test image honoring ENABLE_SUBSAMPLING. */
 //    private RenderedOp readTestImage(File inputFile) throws IOException {
-//        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+//        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
 //        pbjImageRead.setParameter("Input", inputFile);
 //        if (ENABLE_SUBSAMPLING) {
 //            ImageReadParam readParam = new ImageReadParam();
@@ -2017,7 +2017,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        final File out = TestData.temp(this, outName, deleteTempFilesOnExit);
 //
 //        // Prepare writer + output
-//        final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI("ImageWrite");
+//        final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN("ImageWrite");
 //        pbjImageWrite.setParameter("Output", new FileImageOutputStreamExtImpl(out));
 //
 //        ImageWriter writer = new JP2GDALKakaduImageWriterSpi().createWriterInstance();

--- a/plugin/gdal/gdalkakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2kakadu/JP2KWriteTest.java
+++ b/plugin/gdal/gdalkakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2kakadu/JP2KWriteTest.java
@@ -96,7 +96,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // Reading
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -121,7 +121,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -146,7 +146,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -194,7 +194,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // Reading
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -219,7 +219,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -244,7 +244,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -285,7 +285,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -311,7 +311,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -337,7 +337,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -378,7 +378,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -403,7 +403,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -428,7 +428,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -453,7 +453,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite3.setParameter("writeParam", param3);
 //
 //        // Writing
-//        final RenderedOp op3 = JAI.create("ImageWrite", pbjImageWrite3);
+//        final RenderedOp op3 = ImageN.create("ImageWrite", pbjImageWrite3);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -492,7 +492,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -517,7 +517,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -542,7 +542,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -574,7 +574,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -616,7 +616,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //            pbjImageWrite.setParameter("writeParam", param);
 //
 //            // Writing
-//            final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//            final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //        }
 //    }
 //
@@ -656,7 +656,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -681,7 +681,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -706,7 +706,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -745,7 +745,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -770,7 +770,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -795,7 +795,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -834,7 +834,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -859,7 +859,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -884,7 +884,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -918,7 +918,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -965,7 +965,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //            pbjImageWrite.setParameter("writeParam", param);
 //
 //            // Writing
-//            final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//            final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //        }
 //    }
 //
@@ -1007,7 +1007,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1032,7 +1032,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1057,7 +1057,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -1115,7 +1115,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1177,7 +1177,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1202,7 +1202,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1227,7 +1227,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -1265,7 +1265,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1290,7 +1290,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1315,7 +1315,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -1361,7 +1361,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        // Reading
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1387,7 +1387,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1413,7 +1413,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -1453,7 +1453,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1477,7 +1477,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1508,7 +1508,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -1547,7 +1547,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1572,7 +1572,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1597,7 +1597,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -1645,7 +1645,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1670,7 +1670,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1695,7 +1695,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1719,7 +1719,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite3.setParameter("writeParam", param3);
 //
 //        // Writing
-//        final RenderedOp op3 = JAI.create("ImageWrite", pbjImageWrite3);
+//        final RenderedOp op3 = ImageN.create("ImageWrite", pbjImageWrite3);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -1766,7 +1766,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1791,7 +1791,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1816,7 +1816,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -1855,7 +1855,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1880,7 +1880,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //
 //        // ////////////////////////////////////////////////////////////////////
 //        //
@@ -1905,7 +1905,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite2.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op2 = JAI.create("ImageWrite", pbjImageWrite2);
+//        final RenderedOp op2 = ImageN.create("ImageWrite", pbjImageWrite2);
 //    }
 //
 //    // ////////////////////////////////////////////////////////////////////////
@@ -1937,7 +1937,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageRead.setParameter("readParam", param);
 //        pbjImageRead.setParameter("Input", inputFile);
 //        pbjImageRead.setParameter("reader", reader);
-//        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+//        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 //        image.getRendering();
 //        if (TestData.isInteractiveTest())
 //            ImageIOUtilities.visualize(image, "First Read Image");
@@ -1967,7 +1967,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", param2);
 //
 //        // Writing
-//        final RenderedOp op = JAI.create("ImageWrite", pbjImageWrite);
+//        final RenderedOp op = ImageN.create("ImageWrite", pbjImageWrite);
 //        final ImageWriter writer2 = (ImageWriter) op
 //                .getProperty(ImageWriteDescriptor.PROPERTY_NAME_IMAGE_WRITER);
 //        writer2.dispose();
@@ -1981,7 +1981,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageReRead.setParameter("Input", outputFile);
 //        pbjImageReRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi()
 //                .createReaderInstance());
-//        final RenderedOp image2 = JAI.create("ImageRead", pbjImageReRead);
+//        final RenderedOp image2 = ImageN.create("ImageRead", pbjImageReRead);
 //        if (TestData.isInteractiveTest())
 //            ImageIOUtilities.visualize(image2, "Written Image");
 //        else
@@ -2000,7 +2000,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //            pbjImageRead.setParameter("readParam", readParam);
 //        }
 //        pbjImageRead.setParameter("Reader", new JP2GDALKakaduImageReaderSpi().createReaderInstance());
-//        return JAI.create("ImageRead", pbjImageRead);
+//        return ImageN.create("ImageRead", pbjImageRead);
 //    }
 
 //    /**
@@ -2036,7 +2036,7 @@ public class JP2KWriteTest extends AbstractJP2KTestCase {
 //        pbjImageWrite.setParameter("writeParam", iwp);
 //
 //        // Do the write
-//        JAI.create("ImageWrite", pbjImageWrite);
+//        ImageN.create("ImageWrite", pbjImageWrite);
 //        return out;
 //    }
 }

--- a/plugin/gdal/gdalmrsid/src/test/java/it/geosolutions/imageio/plugins/mrsid/MrSIDTest.java
+++ b/plugin/gdal/gdalmrsid/src/test/java/it/geosolutions/imageio/plugins/mrsid/MrSIDTest.java
@@ -44,7 +44,7 @@ import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.metadata.IIOMetadata;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RasterFactory;
 import org.eclipse.imagen.RenderedOp;
 
@@ -95,7 +95,7 @@ public class MrSIDTest extends AbstractGDALTest {
         }
         try {
             final File file = TestData.file(this, fileName);
-            final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+            final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
             pbjImageRead.setParameter("Input", file);
             RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
             IIOMetadata metadata = (IIOMetadata) image
@@ -155,7 +155,7 @@ public class MrSIDTest extends AbstractGDALTest {
             // ////////////////////////////////////////////////////////////////
             // preparing to read
             // ////////////////////////////////////////////////////////////////
-            final ParameterBlockJAI pbjImageRead;
+            final ParameterBlockImageN pbjImageRead;
             final ImageReadParam irp = new ImageReadParam();
 
             // subsample by 2 on both dimensions
@@ -171,7 +171,7 @@ public class MrSIDTest extends AbstractGDALTest {
             l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512)
                     .setTileWidth(512);
 
-            pbjImageRead = new ParameterBlockJAI("ImageRead");
+            pbjImageRead = new ParameterBlockImageN("ImageRead");
             pbjImageRead.setParameter("Input", file);
             pbjImageRead.setParameter("readParam", irp);
 
@@ -187,7 +187,7 @@ public class MrSIDTest extends AbstractGDALTest {
             // ////////////////////////////////////////////////////////////////
             // preparing to crop
             // ////////////////////////////////////////////////////////////////
-            final ParameterBlockJAI pbjCrop = new ParameterBlockJAI("Crop");
+            final ParameterBlockImageN pbjCrop = new ParameterBlockImageN("Crop");
             pbjCrop.addSource(image);
 
             Float xCrop = new Float(image.getWidth() * 3 / 4.0
@@ -211,7 +211,7 @@ public class MrSIDTest extends AbstractGDALTest {
             // ////////////////////////////////////////////////////////////////
             // preparing to translate
             // ////////////////////////////////////////////////////////////////
-            final ParameterBlockJAI pbjTranslate = new ParameterBlockJAI(
+            final ParameterBlockImageN pbjTranslate = new ParameterBlockImageN(
                     "Translate");
             pbjTranslate.addSource(croppedImage);
 
@@ -232,7 +232,7 @@ public class MrSIDTest extends AbstractGDALTest {
             // preparing to rotate
             // ////////////////////////////////////////////////////////////////
 
-            final ParameterBlockJAI pbjRotate = new ParameterBlockJAI("Rotate");
+            final ParameterBlockImageN pbjRotate = new ParameterBlockImageN("Rotate");
             pbjRotate.addSource(translatedImage);
 
             Float xOrigin = new Float(cropWidth.floatValue() / 2);
@@ -324,7 +324,7 @@ public class MrSIDTest extends AbstractGDALTest {
             // Preparing the ImageRead operation
             //
             // //
-            ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+            ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
             pbjImageRead.setParameter("Input", file);
             pbjImageRead.setParameter("readParam", param);
             pbjImageRead.setParameter("reader", reader);

--- a/plugin/gdal/gdalmrsid/src/test/java/it/geosolutions/imageio/plugins/mrsid/MrSIDTest.java
+++ b/plugin/gdal/gdalmrsid/src/test/java/it/geosolutions/imageio/plugins/mrsid/MrSIDTest.java
@@ -43,7 +43,7 @@ import javax.imageio.ImageReader;
 import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.metadata.IIOMetadata;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RasterFactory;
 import org.eclipse.imagen.RenderedOp;
@@ -97,7 +97,7 @@ public class MrSIDTest extends AbstractGDALTest {
             final File file = TestData.file(this, fileName);
             final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
             pbjImageRead.setParameter("Input", file);
-            RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+            RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
             IIOMetadata metadata = (IIOMetadata) image
                     .getProperty(ImageReadDescriptor.PROPERTY_NAME_METADATA_IMAGE);
             Assert.assertTrue(metadata instanceof GDALCommonIIOImageMetadata);
@@ -139,7 +139,7 @@ public class MrSIDTest extends AbstractGDALTest {
     }
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -176,8 +176,8 @@ public class MrSIDTest extends AbstractGDALTest {
             pbjImageRead.setParameter("readParam", irp);
 
             // get a RenderedImage
-            RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                    new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+            RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                    new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
             if (TestData.isInteractiveTest())
                 Viewer.visualizeAllInformation(image, "Subsampling Read");
@@ -202,7 +202,7 @@ public class MrSIDTest extends AbstractGDALTest {
             pbjCrop.setParameter("width", cropWidth);
             pbjCrop.setParameter("height", cropHeigth);
 
-            final RenderedOp croppedImage = JAI.create("Crop", pbjCrop);
+            final RenderedOp croppedImage = ImageN.create("Crop", pbjCrop);
             if (TestData.isInteractiveTest())
                 Viewer.visualizeAllInformation(croppedImage, "Cropped Image");
             else
@@ -221,7 +221,7 @@ public class MrSIDTest extends AbstractGDALTest {
             pbjTranslate.setParameter("xTrans", xTrans);
             pbjTranslate.setParameter("yTrans", yTrans);
 
-            final RenderedOp translatedImage = JAI.create("Translate",
+            final RenderedOp translatedImage = ImageN.create("Translate",
                     pbjTranslate);
             if (TestData.isInteractiveTest())
                 Viewer.visualizeAllInformation(translatedImage, "Translated Image");
@@ -243,7 +243,7 @@ public class MrSIDTest extends AbstractGDALTest {
             pbjRotate.setParameter("yOrigin", yOrigin);
             pbjRotate.setParameter("angle", angle);
 
-            final RenderedOp rotatedImage = JAI.create("Rotate", pbjRotate);
+            final RenderedOp rotatedImage = ImageN.create("Rotate", pbjRotate);
             if (TestData.isInteractiveTest())
                 Viewer.visualizeAllInformation(rotatedImage, "Rotated Image");
             else {
@@ -337,8 +337,8 @@ public class MrSIDTest extends AbstractGDALTest {
             final ImageLayout l = new ImageLayout();
             l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(256)
                     .setTileWidth(256);
-            RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                    new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+            RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                    new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
             if (TestData.isInteractiveTest())
                 Viewer.visualizeAllInformation(image, "SourceBand selection");

--- a/plugin/gdal/gdalmrsidjp2/src/test/java/it/geosolutions/imageio/plugins/jp2mrsid/JP2KReadTest.java
+++ b/plugin/gdal/gdalmrsidjp2/src/test/java/it/geosolutions/imageio/plugins/jp2mrsid/JP2KReadTest.java
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -42,7 +42,7 @@ import org.junit.Test;
 
 /**
  * Testing reading capabilities for {@link JP2GDALMrSidImageReader} leveraging
- * on JAI.
+ * on ImageN.
  * 
  * @author Daniele Romagnoli, GeoSolutions.
  * @author Simone Giannecchini, GeoSolutions.
@@ -99,8 +99,8 @@ public class JP2KReadTest extends AbstractGDALTest {
         final ImageLayout layout = new ImageLayout();
         layout.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(256)
                 .setTileWidth(256);
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, layout));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, layout));
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image,fileName);
         else
@@ -109,7 +109,7 @@ public class JP2KReadTest extends AbstractGDALTest {
     }
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -144,8 +144,8 @@ public class JP2KReadTest extends AbstractGDALTest {
         final ImageLayout layout = new ImageLayout();
         layout.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512)
                 .setTileWidth(512);
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, layout));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, layout));
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image, "subsampled");
@@ -165,7 +165,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         pbjCrop.setParameter("y", yCrop);
         pbjCrop.setParameter("width", cropWidth);
         pbjCrop.setParameter("height", cropHeigth);
-        final RenderedOp croppedImage = JAI.create("Crop", pbjCrop);
+        final RenderedOp croppedImage = ImageN.create("Crop", pbjCrop);
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(croppedImage, "cropped");
@@ -180,7 +180,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         Float yTrans = new Float(yCrop.floatValue() * (-1));
         pbjTranslate.setParameter("xTrans", xTrans);
         pbjTranslate.setParameter("yTrans", yTrans);
-        final RenderedOp translatedImage = JAI
+        final RenderedOp translatedImage = ImageN
                 .create("Translate", pbjTranslate);
 
         if (TestData.isInteractiveTest())
@@ -200,7 +200,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         pbjRotate.setParameter("yOrigin", yOrigin);
         pbjRotate.setParameter("angle", angle);
 
-        final RenderedOp rotatedImage = JAI.create("Rotate", pbjRotate);
+        final RenderedOp rotatedImage = ImageN.create("Rotate", pbjRotate);
 
         StringBuilder title = new StringBuilder("SUBSAMP:").append("X[").append(
                 xSubSampling.toString()).append("]-Y[").append(

--- a/plugin/gdal/gdalmrsidjp2/src/test/java/it/geosolutions/imageio/plugins/jp2mrsid/JP2KReadTest.java
+++ b/plugin/gdal/gdalmrsidjp2/src/test/java/it/geosolutions/imageio/plugins/jp2mrsid/JP2KReadTest.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.gdal.gdal.Driver;
@@ -90,9 +90,9 @@ public class JP2KReadTest extends AbstractGDALTest {
         if (!isJp2MrSidDriverAvailable) {
             return;
         }
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final File file = TestData.file(this, fileName);
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("Reader", new JP2GDALMrSidImageReaderSpi()
                 .createReaderInstance());
@@ -124,7 +124,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
         Integer xSubSampling = new Integer(2);
@@ -136,7 +136,7 @@ public class JP2KReadTest extends AbstractGDALTest {
                 .intValue(), xSubSamplingOffset.intValue(), ySubSamplingOffset
                 .intValue());
 
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", inputFile);
         pbjImageRead.setParameter("readParam", irp);
         pbjImageRead.setParameter("Reader", new JP2GDALMrSidImageReaderSpi()
@@ -153,7 +153,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to crop
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjCrop = new ParameterBlockJAI("Crop");
+        final ParameterBlockImageN pbjCrop = new ParameterBlockImageN("Crop");
         pbjCrop.addSource(image);
 
         // Setting a square crop to avoid blanks zone when rotating.
@@ -173,7 +173,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to translate
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjTranslate = new ParameterBlockJAI(
+        final ParameterBlockImageN pbjTranslate = new ParameterBlockImageN(
                 "Translate");
         pbjTranslate.addSource(croppedImage);
         Float xTrans = new Float(xCrop.floatValue() * (-1));
@@ -189,7 +189,7 @@ public class JP2KReadTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to rotate
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjRotate = new ParameterBlockJAI("Rotate");
+        final ParameterBlockImageN pbjRotate = new ParameterBlockImageN("Rotate");
         pbjRotate.addSource(translatedImage);
 
         Float xOrigin = new Float(cropWidth.floatValue() / 2);

--- a/plugin/gdal/gdalnitf/src/test/java/it/geosolutions/imageio/plugins/nitf/NITFTest.java
+++ b/plugin/gdal/gdalnitf/src/test/java/it/geosolutions/imageio/plugins/nitf/NITFTest.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -64,7 +64,7 @@ public class NITFTest extends  AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
         // subsample by 2 on both dimensions
@@ -74,7 +74,7 @@ public class NITFTest extends  AbstractGDALTest {
         final int ySubSamplingOffset = 0;
         irp.setSourceSubsampling(xSubSampling, ySubSampling,
                 xSubSamplingOffset, ySubSamplingOffset);
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
 

--- a/plugin/gdal/gdalnitf/src/test/java/it/geosolutions/imageio/plugins/nitf/NITFTest.java
+++ b/plugin/gdal/gdalnitf/src/test/java/it/geosolutions/imageio/plugins/nitf/NITFTest.java
@@ -26,7 +26,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import javax.imageio.ImageReadParam;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -44,7 +44,7 @@ public class NITFTest extends  AbstractGDALTest {
 
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -79,7 +79,7 @@ public class NITFTest extends  AbstractGDALTest {
         pbjImageRead.setParameter("readParam", irp);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image, "Subsampling Read");

--- a/plugin/gdal/gdalrpftoc/src/test/java/it/geosolutions/imageio/plugins/rpftoc/RPFTOCTest.java
+++ b/plugin/gdal/gdalrpftoc/src/test/java/it/geosolutions/imageio/plugins/rpftoc/RPFTOCTest.java
@@ -27,7 +27,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import javax.imageio.ImageReadParam;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -73,7 +73,7 @@ public class RPFTOCTest extends  AbstractGDALTest {
         pbjImageRead.setParameter("readParam", irp);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image, "Subsampling Read");

--- a/plugin/gdal/gdalrpftoc/src/test/java/it/geosolutions/imageio/plugins/rpftoc/RPFTOCTest.java
+++ b/plugin/gdal/gdalrpftoc/src/test/java/it/geosolutions/imageio/plugins/rpftoc/RPFTOCTest.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -58,7 +58,7 @@ public class RPFTOCTest extends  AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
         // subsample by 2 on both dimensions
@@ -68,7 +68,7 @@ public class RPFTOCTest extends  AbstractGDALTest {
         final int ySubSamplingOffset = 0;
         irp.setSourceSubsampling(xSubSampling, ySubSampling,
                 xSubSamplingOffset, ySubSamplingOffset);
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
 

--- a/plugin/gdal/gdalsrp/src/test/java/it/geosolutions/imageio/plugins/srp/SPRTest.java
+++ b/plugin/gdal/gdalsrp/src/test/java/it/geosolutions/imageio/plugins/srp/SPRTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.image.Raster;
 import java.io.File;
@@ -51,7 +51,7 @@ public class SPRTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
         // subsample by 2 on both dimensions
@@ -61,7 +61,7 @@ public class SPRTest extends AbstractGDALTest {
         final int ySubSamplingOffset = 0;
         irp.setSourceSubsampling(xSubSampling, ySubSampling,
                 xSubSamplingOffset, ySubSamplingOffset);
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
 

--- a/plugin/gdal/gdalsrp/src/test/java/it/geosolutions/imageio/plugins/srp/SPRTest.java
+++ b/plugin/gdal/gdalsrp/src/test/java/it/geosolutions/imageio/plugins/srp/SPRTest.java
@@ -24,7 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import javax.imageio.ImageReadParam;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.image.Raster;
@@ -66,7 +66,7 @@ public class SPRTest extends AbstractGDALTest {
         pbjImageRead.setParameter("readParam", irp);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image, "Subsampling Read");

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/ArcGridReadVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/ArcGridReadVrtTest.java
@@ -27,7 +27,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.*;
 import java.awt.image.RenderedImage;
@@ -60,10 +60,10 @@ public class ArcGridReadVrtTest extends AbstractGDALTest {
 		if (!isGDALAvailable) {
 			return;
 		}
-		final ParameterBlockJAI pbjImageRead;
+		final ParameterBlockImageN pbjImageRead;
 		final String fileName = "095b_dem_90m.asc.vrt";
 		final File file = TestData.file(this, fileName);
-		pbjImageRead = new ParameterBlockJAI("ImageRead");
+		pbjImageRead = new ParameterBlockImageN("ImageRead");
 		pbjImageRead.setParameter("Input", file);
 		RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 		if (TestData.isInteractiveTest())

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/ArcGridReadVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/ArcGridReadVrtTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.*;
@@ -38,7 +38,7 @@ import java.util.Iterator;
 
 /**
  * Testing reading capabilities for ArcGrid with {@link VRTImageReader}.
- * JAI.
+ * ImageN.
  * 
  * @author Simone Giannecchini, GeoSolutions.
  * @author Daniele Romagnoli, GeoSolutions.
@@ -50,7 +50,7 @@ public class ArcGridReadVrtTest extends AbstractGDALTest {
 	}
 
 	/**
-	 * Simple test read through JAI - ImageIO
+	 * Simple test read through ImageN - ImageIO
 	 *
 	 * @throws FileNotFoundException
 	 * @throws IOException
@@ -65,7 +65,7 @@ public class ArcGridReadVrtTest extends AbstractGDALTest {
 		final File file = TestData.file(this, fileName);
 		pbjImageRead = new ParameterBlockJAI("ImageRead");
 		pbjImageRead.setParameter("Input", file);
-		RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+		RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 		if (TestData.isInteractiveTest())
 			Viewer.visualizeAllInformation(image, fileName);
 		else

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/BsbVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/BsbVrtTest.java
@@ -25,7 +25,7 @@ import org.junit.Before;
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.*;
 import java.io.File;
@@ -61,10 +61,10 @@ public class BsbVrtTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
 

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/BsbVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/BsbVrtTest.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.*;
@@ -46,7 +46,7 @@ public class BsbVrtTest extends AbstractGDALTest {
     }
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -72,7 +72,7 @@ public class BsbVrtTest extends AbstractGDALTest {
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(32).setTileWidth(32);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
         if (TestData.isInteractiveTest()) {
             ImageIOUtilities.visualize(image, "test", true);

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/Doq1VrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/Doq1VrtTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.*;
@@ -44,7 +44,7 @@ public class Doq1VrtTest extends AbstractGDALTest {
     public final static String fileName = "fakedoq1.doq.vrt";
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -75,7 +75,7 @@ public class Doq1VrtTest extends AbstractGDALTest {
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(32).setTileWidth(32);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
         if (TestData.isInteractiveTest()) {
             Viewer.visualizeAllInformation(image, "test");

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/Doq1VrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/Doq1VrtTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.*;
 import java.io.File;
@@ -59,10 +59,10 @@ public class Doq1VrtTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
         

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/Doq2VrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/Doq2VrtTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.*;
@@ -50,7 +50,7 @@ public class Doq2VrtTest extends AbstractGDALTest {
     }
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -81,7 +81,7 @@ public class Doq2VrtTest extends AbstractGDALTest {
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
         if (TestData.isInteractiveTest()) {
             Viewer.visualizeAllInformation(image, "test");

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/Doq2VrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/Doq2VrtTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.*;
 import java.io.File;
@@ -65,10 +65,10 @@ public class Doq2VrtTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
 

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/DtedVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/DtedVrtTest.java
@@ -45,7 +45,7 @@ public class DtedVrtTest extends AbstractGDALTest {
     }
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/ErdasImgVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/ErdasImgVrtTest.java
@@ -25,7 +25,7 @@ import org.eclipse.imagen.ImageLayout;
 import org.junit.Assert;
 import org.junit.Test;
 
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -50,7 +50,7 @@ public class ErdasImgVrtTest extends AbstractGDALTest {
     public final static String fileName = "sample-erdas.img.vrt";
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -70,7 +70,7 @@ public class ErdasImgVrtTest extends AbstractGDALTest {
         pbjImageRead.setParameter("Input", file);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image, "Read");
@@ -105,10 +105,10 @@ public class ErdasImgVrtTest extends AbstractGDALTest {
         ImageLayout layout = new ImageLayout().setTileHeight(256).setTileWidth(256);
         layout.setColorModel(cm);
         layout.setSampleModel(sm);
-        RenderingHints hints = new RenderingHints(JAI.KEY_IMAGE_LAYOUT, layout);
+        RenderingHints hints = new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, layout);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead, hints);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead, hints);
 
         sm = image.getSampleModel();
         cm = image.getColorModel();

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/ErdasImgVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/ErdasImgVrtTest.java
@@ -26,7 +26,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import javax.imageio.ImageReadParam;
@@ -65,8 +65,8 @@ public class ErdasImgVrtTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        final ParameterBlockImageN pbjImageRead;
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
 
         // get a RenderedImage
@@ -89,8 +89,8 @@ public class ErdasImgVrtTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        final ParameterBlockImageN pbjImageRead;
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         ImageReadParam param = new ImageReadParam();
         param.setSourceBands(new int[] { 2 });

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/GeoTiffVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/GeoTiffVrtTest.java
@@ -28,7 +28,7 @@ import it.geosolutions.imageio.stream.output.FileImageOutputStreamExtImpl;
 import it.geosolutions.imageio.utilities.ImageIOUtilities;
 import it.geosolutions.resources.TestData;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 import org.junit.Assert;
@@ -132,7 +132,7 @@ public class GeoTiffVrtTest extends AbstractGDALTest {
         pbjImageRead = new ParameterBlockJAI("ImageRead");
         pbjImageRead.setParameter("Input", new FileImageInputStreamExtImpl(file));
         pbjImageRead.setParameter("Reader", new VRTImageReaderSpi().createReaderInstance());
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image, "", true);
         else
@@ -169,7 +169,7 @@ public class GeoTiffVrtTest extends AbstractGDALTest {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(256).setTileWidth(256);
 
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image,"geotiff");
@@ -188,7 +188,7 @@ public class GeoTiffVrtTest extends AbstractGDALTest {
         final ParameterBlockJAI pbjImageReRead = new ParameterBlockJAI("ImageRead");
         pbjImageReRead.setParameter("Input", outputFile);
         pbjImageReRead.setParameter("Reader", new GeoTiffImageReaderSpi() .createReaderInstance());
-        final RenderedOp image2 = JAI.create("ImageRead", pbjImageReRead);
+        final RenderedOp image2 = ImageN.create("ImageRead", pbjImageReRead);
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image2,"geotif2");
         else
@@ -221,7 +221,7 @@ public class GeoTiffVrtTest extends AbstractGDALTest {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(256).setTileWidth(256);
 
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead, new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead, new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image, "Paletted image read");
@@ -239,7 +239,7 @@ public class GeoTiffVrtTest extends AbstractGDALTest {
         final ParameterBlockJAI pbjImageReRead = new ParameterBlockJAI("ImageRead");
         pbjImageReRead.setParameter("Input", outputFile);
         pbjImageReRead.setParameter("Reader", new GeoTiffImageReaderSpi().createReaderInstance());
-        final RenderedOp image2 = JAI.create("ImageRead", pbjImageReRead);
+        final RenderedOp image2 = ImageN.create("ImageRead", pbjImageReRead);
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image2,"Paletted image read back after writing");
         else

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/GeoTiffVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/GeoTiffVrtTest.java
@@ -29,7 +29,7 @@ import it.geosolutions.imageio.utilities.ImageIOUtilities;
 import it.geosolutions.resources.TestData;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 import org.junit.Assert;
 import org.junit.Before;
@@ -125,11 +125,11 @@ public class GeoTiffVrtTest extends AbstractGDALTest {
         if (!isGDALAvailable) {
             return;
         }
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         String fileName = "utmByte.tif.vrt";
         final File file = TestData.file(this, fileName);
 
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", new FileImageInputStreamExtImpl(file));
         pbjImageRead.setParameter("Reader", new VRTImageReaderSpi().createReaderInstance());
         RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
@@ -161,7 +161,7 @@ public class GeoTiffVrtTest extends AbstractGDALTest {
         reader.setInput(inputFile);
         final IIOMetadata metadata = reader.getImageMetadata(0);
 
-        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", inputFile);
         pbjImageRead.setParameter("reader", reader);
         pbjImageRead.setParameter("readParam", rparam);
@@ -185,7 +185,7 @@ public class GeoTiffVrtTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read again
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageReRead = new ParameterBlockJAI("ImageRead");
+        final ParameterBlockImageN pbjImageReRead = new ParameterBlockImageN("ImageRead");
         pbjImageReRead.setParameter("Input", outputFile);
         pbjImageReRead.setParameter("Reader", new GeoTiffImageReaderSpi() .createReaderInstance());
         final RenderedOp image2 = ImageN.create("ImageRead", pbjImageReRead);
@@ -214,7 +214,7 @@ public class GeoTiffVrtTest extends AbstractGDALTest {
         reader.setInput(inputFile);
         final IIOMetadata metadata = reader.getImageMetadata(0);
 
-        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI("ImageRead");
+        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", inputFile);
         pbjImageRead.setParameter("reader", reader);
 
@@ -236,7 +236,7 @@ public class GeoTiffVrtTest extends AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read again
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageReRead = new ParameterBlockJAI("ImageRead");
+        final ParameterBlockImageN pbjImageReRead = new ParameterBlockImageN("ImageRead");
         pbjImageReRead.setParameter("Input", outputFile);
         pbjImageReRead.setParameter("Reader", new GeoTiffImageReaderSpi().createReaderInstance());
         final RenderedOp image2 = ImageN.create("ImageRead", pbjImageReRead);

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/IdrisiReadVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/IdrisiReadVrtTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.*;
@@ -49,7 +49,7 @@ public class IdrisiReadVrtTest extends AbstractGDALTest {
 	}
 
 	/**
-	 * Simple test read through JAI - ImageIO
+	 * Simple test read through ImageN - ImageIO
 	 *
 	 * @throws FileNotFoundException
 	 * @throws IOException
@@ -65,7 +65,7 @@ public class IdrisiReadVrtTest extends AbstractGDALTest {
 		final File file = TestData.file(this, fileName);
 		pbjImageRead = new ParameterBlockJAI("ImageRead");
 		pbjImageRead.setParameter("Input", file);
-		RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+		RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 		if (TestData.isInteractiveTest())
 			Viewer.visualizeAllInformation(image, fileName);
 		else

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/IdrisiReadVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/IdrisiReadVrtTest.java
@@ -27,7 +27,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.*;
 import java.awt.image.RenderedImage;
@@ -59,11 +59,11 @@ public class IdrisiReadVrtTest extends AbstractGDALTest {
 		if (!isGDALAvailable) {
 			return;
 		}
-		final ParameterBlockJAI pbjImageRead;
+		final ParameterBlockImageN pbjImageRead;
 		final String fileName = "idrisi.rst.vrt";
 		TestData.unzipFile(this, "idrisi.zip");
 		final File file = TestData.file(this, fileName);
-		pbjImageRead = new ParameterBlockJAI("ImageRead");
+		pbjImageRead = new ParameterBlockImageN("ImageRead");
 		pbjImageRead.setParameter("Input", file);
 		RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 		if (TestData.isInteractiveTest())

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/JpegVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/JpegVrtTest.java
@@ -29,7 +29,7 @@ import javax.imageio.ImageReader;
 import javax.imageio.ImageTypeSpecifier;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.*;
 import java.awt.color.ColorSpace;
@@ -59,12 +59,12 @@ public class JpegVrtTest extends AbstractGDALTest {
         if (!isGDALAvailable) {
             return;
         }
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
         final String fileName = "bw_sample.jpg.vrt";
         final File file = TestData.file(this, fileName);
         irp.setSourceSubsampling(1, 2, 0, 0);
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
 
@@ -146,7 +146,7 @@ public class JpegVrtTest extends AbstractGDALTest {
         // Preparing for image read operation
         //
         // //
-        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
                 "ImageRead");
         pbjImageRead.setParameter("Input", inputFile);
         pbjImageRead.setParameter("readParam", rparam);

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/JpegVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/JpegVrtTest.java
@@ -28,7 +28,7 @@ import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import javax.imageio.ImageTypeSpecifier;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.*;
@@ -72,8 +72,8 @@ public class JpegVrtTest extends AbstractGDALTest {
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512)
                 .setTileWidth(512);
 
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image,fileName);
         else
@@ -154,8 +154,8 @@ public class JpegVrtTest extends AbstractGDALTest {
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(128)
                 .setTileWidth(128);
 
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image,"imageread");

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/NitfVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/NitfVrtTest.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.junit.Assert;
@@ -58,7 +58,7 @@ public class NitfVrtTest extends  AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
         // subsample by 2 on both dimensions
@@ -68,7 +68,7 @@ public class NitfVrtTest extends  AbstractGDALTest {
         final int ySubSamplingOffset = 0;
         irp.setSourceSubsampling(xSubSampling, ySubSampling,
                 xSubSamplingOffset, ySubSamplingOffset);
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
 

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/NitfVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/NitfVrtTest.java
@@ -26,7 +26,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import javax.imageio.ImageReadParam;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -43,7 +43,7 @@ public class NitfVrtTest extends  AbstractGDALTest {
     public final static String fileName = "001zc013.on1.vrt";
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -73,7 +73,7 @@ public class NitfVrtTest extends  AbstractGDALTest {
         pbjImageRead.setParameter("readParam", irp);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image, "Subsampling Read");

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/RasterAttributeTableTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/RasterAttributeTableTest.java
@@ -29,7 +29,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import javax.imageio.metadata.IIOMetadata;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.Rectangle;

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/RasterAttributeTableTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/RasterAttributeTableTest.java
@@ -30,7 +30,7 @@ import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import javax.imageio.metadata.IIOMetadata;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.Rectangle;
 import java.awt.image.RenderedImage;

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/RpftocVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/RpftocVrtTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 import javax.imageio.ImageReadParam;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.image.Raster;
 import java.io.File;
@@ -52,7 +52,7 @@ public class RpftocVrtTest extends  AbstractGDALTest {
         // ////////////////////////////////////////////////////////////////
         // preparing to read
         // ////////////////////////////////////////////////////////////////
-        final ParameterBlockJAI pbjImageRead;
+        final ParameterBlockImageN pbjImageRead;
         final ImageReadParam irp = new ImageReadParam();
 
         // subsample by 2 on both dimensions
@@ -62,7 +62,7 @@ public class RpftocVrtTest extends  AbstractGDALTest {
         final int ySubSamplingOffset = 0;
         irp.setSourceSubsampling(xSubSampling, ySubSampling,
                 xSubSamplingOffset, ySubSamplingOffset);
-        pbjImageRead = new ParameterBlockJAI("ImageRead");
+        pbjImageRead = new ParameterBlockImageN("ImageRead");
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("readParam", irp);
 

--- a/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/RpftocVrtTest.java
+++ b/plugin/gdal/gdalvrt/src/test/java/it/geosolutions/imageio/plugins/vrt/RpftocVrtTest.java
@@ -24,7 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import javax.imageio.ImageReadParam;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 import java.awt.image.Raster;
@@ -67,7 +67,7 @@ public class RpftocVrtTest extends  AbstractGDALTest {
         pbjImageRead.setParameter("readParam", irp);
 
         // get a RenderedImage
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
 
         if (TestData.isInteractiveTest())
             Viewer.visualizeAllInformation(image, "Subsampling Read");

--- a/plugin/gdal/gdalwcs/src/test/java/it/geosolutions/imageio/plugins/wcs/WCSTest.java
+++ b/plugin/gdal/gdalwcs/src/test/java/it/geosolutions/imageio/plugins/wcs/WCSTest.java
@@ -47,7 +47,7 @@ public class WCSTest extends AbstractGDALTest {
             && GDALUtilities.isDriverAvailable("WCS");
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException

--- a/plugin/gdal/gdalwms/src/test/java/it/geosolutions/imageio/plugins/wms/WMSTest.java
+++ b/plugin/gdal/gdalwms/src/test/java/it/geosolutions/imageio/plugins/wms/WMSTest.java
@@ -45,7 +45,7 @@ public class WMSTest extends AbstractGDALTest {
             && GDALUtilities.isDriverAvailable("WMS");
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException

--- a/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/AbstractJP2KakaduTestCase.java
+++ b/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/AbstractJP2KakaduTestCase.java
@@ -17,7 +17,7 @@
 package it.geosolutions.imageio.plugins.jp2k;
 
 import it.geosolutions.util.KakaduUtilities;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 
 public class AbstractJP2KakaduTestCase {
     protected static boolean runTests;
@@ -28,12 +28,12 @@ public class AbstractJP2KakaduTestCase {
 
     public void setUp() throws Exception {
         // general settings
-         JAI.getDefaultInstance().getTileScheduler().setParallelism(2);
-         JAI.getDefaultInstance().getTileScheduler().setPriority(6);
-         JAI.getDefaultInstance().getTileScheduler().setPrefetchPriority(2);
-         JAI.getDefaultInstance().getTileScheduler().setPrefetchParallelism(1);
-         JAI.getDefaultInstance().getTileCache().setMemoryCapacity(
+         ImageN.getDefaultInstance().getTileScheduler().setParallelism(2);
+         ImageN.getDefaultInstance().getTileScheduler().setPriority(6);
+         ImageN.getDefaultInstance().getTileScheduler().setPrefetchPriority(2);
+         ImageN.getDefaultInstance().getTileScheduler().setPrefetchParallelism(1);
+         ImageN.getDefaultInstance().getTileCache().setMemoryCapacity(
          64 * 1024 * 1024);
-         JAI.getDefaultInstance().getTileCache().setMemoryThreshold(1.0f);
+         ImageN.getDefaultInstance().getTileCache().setMemoryThreshold(1.0f);
     }
 }

--- a/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/JP2KKakaduWriteTest.java
+++ b/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/JP2KKakaduWriteTest.java
@@ -21,7 +21,7 @@ package it.geosolutions.imageio.plugins.jp2k;
 import it.geosolutions.resources.TestData;
 import it.geosolutions.util.KakaduUtilities;
 import kdu_jni.KduException;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 import org.junit.Assume;
@@ -191,7 +191,7 @@ public class JP2KKakaduWriteTest {
     
                     pbjImageRead.setParameter("reader", reader);
                     pbjImageRead.setParameter("Input", file);
-                    RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+                    RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
     
                     write(config.outputFileName, image, config.writeCodeStreamOnly,
                             config.quality, config.useJAI, config.param);
@@ -256,7 +256,7 @@ public class JP2KKakaduWriteTest {
 
             pbjImageRead.setParameter("reader", reader);
             pbjImageRead.setParameter("Input", file);
-            RenderedOp image = JAI.create("ImageRead", pbjImageRead);
+            RenderedOp image = ImageN.create("ImageRead", pbjImageRead);
             write(config.outputFileName, image, config.writeCodeStreamOnly,
                     config.quality, config.useJAI, config.param);
         }
@@ -311,7 +311,7 @@ public class JP2KKakaduWriteTest {
             pbjImageWrite.setParameter("output", outputStream);
             pbjImageWrite.setParameter("writeParam", param);
             pbjImageWrite.addSource(bi);
-            RenderedOp image = JAI.create("ImageWrite", pbjImageWrite);
+            RenderedOp image = ImageN.create("ImageWrite", pbjImageWrite);
         }
     }
 

--- a/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/JP2KKakaduWriteTest.java
+++ b/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/JP2KKakaduWriteTest.java
@@ -22,7 +22,7 @@ import it.geosolutions.resources.TestData;
 import it.geosolutions.util.KakaduUtilities;
 import kdu_jni.KduException;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 import org.junit.Assume;
 import org.junit.Before;
@@ -184,7 +184,7 @@ public class JP2KKakaduWriteTest {
     
                 for (TestConfiguration config : configs) {
     
-                    final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+                    final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
                             "ImageRead");
                     ImageReader reader = ImageIO.getImageReaders(
                             ImageIO.createImageInputStream(file)).next();
@@ -249,7 +249,7 @@ public class JP2KKakaduWriteTest {
 
         for (TestConfiguration config : configs) {
 
-            final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+            final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
                     "ImageRead");
             ImageReader reader = ImageIO.getImageReaders(
                     ImageIO.createImageInputStream(file)).next();
@@ -302,7 +302,7 @@ public class JP2KKakaduWriteTest {
             writer.write(null, new IIOImage(bi, null, null), param);
             writer.dispose();
         } else {
-            final ParameterBlockJAI pbjImageWrite = new ParameterBlockJAI(
+            final ParameterBlockImageN pbjImageWrite = new ParameterBlockImageN(
                     "ImageWrite");
 
             final ImageWriter writer = new JP2KKakaduImageWriterSpi()

--- a/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/JP2KakaduReadTest.java
+++ b/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/JP2KakaduReadTest.java
@@ -20,7 +20,7 @@ import it.geosolutions.imageio.plugins.jp2k.box.XMLBoxMetadataNode;
 import it.geosolutions.imageio.utilities.ImageIOUtilities;
 import it.geosolutions.resources.TestData;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.PlanarImage;
 import org.eclipse.imagen.RenderedOp;
@@ -44,7 +44,7 @@ import static junit.framework.TestCase.assertTrue;
 
 /**
  * Testing reading capabilities for {@link JP2KKakaduImageReader} leveraging on
- * JAI.
+ * ImageN.
  * 
  * @author Simone Giannecchini, GeoSolutions.
  * @author Daniele Romagnoli, GeoSolutions.
@@ -77,8 +77,8 @@ public class JP2KakaduReadTest extends AbstractJP2KakaduTestCase {
         pbjImageRead.setParameter("ReadParam", rp);
         pbjImageRead.setParameter("Input", file);
         pbjImageRead.setParameter("imageChoice", 0);
-        RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+        RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
         if (TestData.isInteractiveTest())
             ImageIOUtilities.visualize(image);
         else
@@ -177,7 +177,7 @@ public class JP2KakaduReadTest extends AbstractJP2KakaduTestCase {
     }
 
     public static void displayStatistics(boolean b, RenderedImage source) {
-        PlanarImage img = JAI.create("extrema", source, null);
+        PlanarImage img = ImageN.create("extrema", source, null);
 
         RenderedImageBrowser.showChain(img, true, true, "Statistics", true);
     }

--- a/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/JP2KakaduReadTest.java
+++ b/plugin/kakadujp2/src/test/java/it/geosolutions/imageio/plugins/jp2k/JP2KakaduReadTest.java
@@ -21,7 +21,7 @@ import it.geosolutions.imageio.utilities.ImageIOUtilities;
 import it.geosolutions.resources.TestData;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.PlanarImage;
 import org.eclipse.imagen.RenderedOp;
 import org.eclipse.imagen.media.viewer.RenderedImageBrowser;
@@ -63,7 +63,7 @@ public class JP2KakaduReadTest extends AbstractJP2KakaduTestCase {
             return;
         final File file = TestData.file(this, "CB_TM432.jp2");
 
-        final ParameterBlockJAI pbjImageRead = new ParameterBlockJAI(
+        final ParameterBlockImageN pbjImageRead = new ParameterBlockImageN(
                 "ImageRead");
         ImageLayout l = new ImageLayout();
         l.setTileHeight(256);

--- a/plugin/png/src/test/java/it/geosolutions/imageioimpl/plugins/png/GrayAlpha8bitTest.java
+++ b/plugin/png/src/test/java/it/geosolutions/imageioimpl/plugins/png/GrayAlpha8bitTest.java
@@ -30,7 +30,7 @@ import java.io.ByteArrayOutputStream;
 
 import javax.imageio.ImageIO;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.PlanarImage;
 import org.eclipse.imagen.media.bandmerge.BandMergeDescriptor;
 import org.eclipse.imagen.media.bandselect.BandSelectDescriptor;
@@ -59,7 +59,7 @@ public class GrayAlpha8bitTest {
                 ImageLayout.SAMPLE_MODEL_MASK);
         RenderedImage alpha = ConstantDescriptor.create(Float.valueOf(bi.getWidth()),
                 Float.valueOf(bi.getHeight()), new Byte[] { Byte.valueOf((byte) 255) },
-                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, tempLayout));
+                new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, tempLayout));
         RenderedImage grayAlpha = BandMergeDescriptor.create(null, 0d, true, null, bi, alpha);
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();

--- a/plugin/png/src/test/java/it/geosolutions/imageioimpl/plugins/png/PngSuiteImagesTest.java
+++ b/plugin/png/src/test/java/it/geosolutions/imageioimpl/plugins/png/PngSuiteImagesTest.java
@@ -37,7 +37,7 @@ import java.util.List;
 
 import javax.imageio.ImageIO;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.RenderedOp;
 import org.eclipse.imagen.media.format.FormatDescriptor;
 
@@ -93,7 +93,7 @@ public class PngSuiteImagesTest {
         il.setTileWidth(8);
         il.setTileHeight(8);
 
-        RenderingHints hints = new RenderingHints(JAI.KEY_IMAGE_LAYOUT, il);
+        RenderingHints hints = new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, il);
         RenderedOp tiled = FormatDescriptor.create(input, input.getSampleModel().getDataType(),
                 hints);
         assertEquals(8, tiled.getTileWidth());

--- a/plugin/tiff/src/test/java/it/geosolutions/imageio/tiff/BandSelectionTest.java
+++ b/plugin/tiff/src/test/java/it/geosolutions/imageio/tiff/BandSelectionTest.java
@@ -188,7 +188,7 @@ public class BandSelectionTest {
                 return reader.read(0, param);
             }
 
-            // deferred read, to go through the JAI machinery figuring out the deferred image layout 
+            // deferred read, to go through the ImageN machinery figuring out the deferred image layout 
             // (and then making it a BufferedImage so that we can dispose the reader safely)
             RenderedOp op = ImageReadDescriptor.create(is, 0, false, false, false, null,
                     null, param, reader, null);

--- a/plugin/tiff/src/test/java/it/geosolutions/imageio/tiff/TIFFReadTest.java
+++ b/plugin/tiff/src/test/java/it/geosolutions/imageio/tiff/TIFFReadTest.java
@@ -57,7 +57,7 @@ import it.geosolutions.imageioimpl.plugins.tiff.TIFFStreamMetadata.MetadataNode;
 import it.geosolutions.resources.TestData;
 
 /**
- * Testing reading capabilities for {@link JP2KKakaduImageReader} leveraging on JAI.
+ * Testing reading capabilities for {@link JP2KKakaduImageReader} leveraging on ImageN.
  * 
  * @author Simone Giannecchini, GeoSolutions.
  * @author Daniele Romagnoli, GeoSolutions.

--- a/plugin/tiff/src/test/java/it/geosolutions/imageio/tiff/TIFFWriteTest.java
+++ b/plugin/tiff/src/test/java/it/geosolutions/imageio/tiff/TIFFWriteTest.java
@@ -48,7 +48,7 @@ import org.eclipse.imagen.media.imageread.ImageReadDescriptor;
 
 
 /**
- * Testing reading capabilities for {@link JP2KKakaduImageReader} leveraging on JAI.
+ * Testing reading capabilities for {@link JP2KKakaduImageReader} leveraging on ImageN.
  * 
  * @author Simone Giannecchini, GeoSolutions.
  * @author Daniele Romagnoli, GeoSolutions.
@@ -171,7 +171,7 @@ public class TIFFWriteTest extends Assert {
     @Test
     public void readWriteFromFileDirect() throws IOException {
 
-//        JAI.getDefaultInstance().getTileCache().setMemoryCapacity(512*1024*1024);
+//        ImageN.getDefaultInstance().getTileCache().setMemoryCapacity(512*1024*1024);
 //        final TCTool tc= new TCTool((SunTileCache)JAI.getDefaultInstance().getTileCache());
         final File inputFile =TestData.file(this, "test.tif");// new File("c:\\work\\dem30_final.tiff");
         final File outputFile = TestData.temp(this, "testw.tif",true);
@@ -190,7 +190,7 @@ public class TIFFWriteTest extends Assert {
         BufferedImage image = reader.read(0, param);
 //        RenderedImage image = ImageReadDescriptor.create(new FileImageInputStream(inputFile),
 //                Integer.valueOf(0), false, false, false, null, null, null,
-//                reader, new RenderingHints(JAI.KEY_IMAGE_LAYOUT, new ImageLayout().setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512)));
+//                reader, new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, new ImageLayout().setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512)));
         
         final TIFFImageWriter writer= (TIFFImageWriter) new TIFFImageWriterSpi().createWriterInstance();
         final ImageWriteParam writeParam= new TIFFImageWriteParam(Locale.getDefault());

--- a/plugin/turbojpeg/src/main/java/it/geosolutions/imageio/plugins/turbojpeg/TurboJpegImageWriter.java
+++ b/plugin/turbojpeg/src/main/java/it/geosolutions/imageio/plugins/turbojpeg/TurboJpegImageWriter.java
@@ -42,7 +42,7 @@ import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.spi.ImageWriterSpi;
 import javax.imageio.stream.ImageOutputStream;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import org.eclipse.imagen.media.opimage.CopyOpImage;
@@ -264,9 +264,9 @@ public class TurboJpegImageWriter extends ImageWriter
             if (srcImage instanceof RenderedOp)
             {
                 hints = ((RenderedOp) srcImage).getRenderingHints();
-                if ((hints != null) && hints.containsKey(JAI.KEY_IMAGE_LAYOUT))
+                if ((hints != null) && hints.containsKey(ImageN.KEY_IMAGE_LAYOUT))
                 {
-                    layout = (ImageLayout) hints.get(JAI.KEY_IMAGE_LAYOUT);
+                    layout = (ImageLayout) hints.get(ImageN.KEY_IMAGE_LAYOUT);
                 }
                 else
                 {
@@ -276,7 +276,7 @@ public class TurboJpegImageWriter extends ImageWriter
             else
             {
                 layout = new ImageLayout(srcImage);
-                hints = new RenderingHints(JAI.KEY_IMAGE_LAYOUT, layout);
+                hints = new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, layout);
             }
             
             // Imposing the layout of the requested image

--- a/plugin/turbojpeg/src/main/java/it/geosolutions/imageio/utilities/TilesByteGetter.java
+++ b/plugin/turbojpeg/src/main/java/it/geosolutions/imageio/utilities/TilesByteGetter.java
@@ -28,7 +28,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.PlanarImage;
 import org.eclipse.imagen.TileScheduler;
 
@@ -149,7 +149,7 @@ public class TilesByteGetter {
                     final int minTx = ri.getMinTileX();
                     final int minTy = ri.getMinTileY();
                     int TH = multithreadingLevel;
-                    final TileScheduler ts = JAI.getDefaultInstance().getTileScheduler();
+                    final TileScheduler ts = ImageN.getDefaultInstance().getTileScheduler();
                     final List<Point> tiles = new ArrayList<Point>();
                     final LinkedBlockingQueue<Runnable> queue = new LinkedBlockingQueue<Runnable>();
                     final List<Callable<Integer>> queueX = new ArrayList<Callable<Integer>>();
@@ -173,7 +173,7 @@ public class TilesByteGetter {
                     if (usePrefetching){
                         final int minTx = ri.getMinTileX();
                         final int minTy = ri.getMinTileY();
-                        TileScheduler ts = JAI.getDefaultInstance().getTileScheduler();
+                        TileScheduler ts = ImageN.getDefaultInstance().getTileScheduler();
                         List<Point> tiles = new ArrayList<Point>();
                         int tx = 0;
                         int ty = 0;

--- a/plugin/turbojpeg/src/test/java/it/geosolutions/imageio/plugins/turbojpeg/JPEGWriterTest.java
+++ b/plugin/turbojpeg/src/test/java/it/geosolutions/imageio/plugins/turbojpeg/JPEGWriterTest.java
@@ -49,7 +49,7 @@ import javax.imageio.stream.FileImageInputStream;
 import javax.imageio.stream.ImageInputStream;
 
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.media.bandselect.BandSelectDescriptor;
 
 import org.junit.Before;
@@ -70,7 +70,7 @@ public class JPEGWriterTest extends BaseTest {
     
     static {
         try {
-            JAI.getDefaultInstance().getTileCache().setMemoryCapacity(128 * 1024 * 1024);
+            ImageN.getDefaultInstance().getTileCache().setMemoryCapacity(128 * 1024 * 1024);
             if (!(INPUT_FILE.exists() && INPUT_FILE.canRead())) {
                 SKIP_TESTS = true;
                 LOGGER.warning(ERROR_FILE_MESSAGE);
@@ -299,7 +299,7 @@ public class JPEGWriterTest extends BaseTest {
             layout.setTileWidth(228);
             layout.setTileHeight(104);
             reader = ImageIO.getImageReaders(stream).next();
-            RenderingHints hints = new RenderingHints(JAI.KEY_IMAGE_LAYOUT, layout);
+            RenderingHints hints = new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, layout);
             BufferedImage sourceImage = ImageIO.read(input);
             sourceImage.getWidth();
             RenderedImage inputImage = BandSelectDescriptor.create(sourceImage, new int[]{0}, hints); 

--- a/plugin/unidata-netcdf/hdf4/src/test/java/it/geosolutions/imageio/plugins/hdf4/terascan/HDF4TeraScanTest.java
+++ b/plugin/unidata-netcdf/hdf4/src/test/java/it/geosolutions/imageio/plugins/hdf4/terascan/HDF4TeraScanTest.java
@@ -32,7 +32,7 @@ import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import javax.imageio.metadata.IIOMetadata;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ParameterBlockJAI;
 import org.eclipse.imagen.RenderedOp;
 
@@ -78,7 +78,7 @@ public class HDF4TeraScanTest extends TestCase {
     }
 
     /**
-     * Test read exploiting common JAI operations (Crop-Translate-Rotate)
+     * Test read exploiting common ImageN operations (Crop-Translate-Rotate)
      * 
      * @throws FileNotFoundException
      * @throws IOException
@@ -110,8 +110,8 @@ public class HDF4TeraScanTest extends TestCase {
             pbjImageRead.setParameter("readParam", irp);
 
             // get a RenderedImage
-            final RenderedOp image = JAI.create("ImageRead", pbjImageRead,
-                    new RenderingHints(JAI.KEY_IMAGE_LAYOUT, l));
+            final RenderedOp image = ImageN.create("ImageRead", pbjImageRead,
+                    new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
 
             
             // Silly equality test

--- a/plugin/unidata-netcdf/hdf4/src/test/java/it/geosolutions/imageio/plugins/hdf4/terascan/HDF4TeraScanTest.java
+++ b/plugin/unidata-netcdf/hdf4/src/test/java/it/geosolutions/imageio/plugins/hdf4/terascan/HDF4TeraScanTest.java
@@ -33,7 +33,7 @@ import javax.imageio.ImageReader;
 import javax.imageio.metadata.IIOMetadata;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
-import org.eclipse.imagen.ParameterBlockJAI;
+import org.eclipse.imagen.ParameterBlockImageN;
 import org.eclipse.imagen.RenderedOp;
 
 import junit.framework.TestCase;
@@ -91,7 +91,7 @@ public class HDF4TeraScanTest extends TestCase {
             // ////////////////////////////////////////////////////////////////
             // preparing the ImageRead
             // ////////////////////////////////////////////////////////////////
-            final ParameterBlockJAI pbjImageRead;
+            final ParameterBlockImageN pbjImageRead;
             final ImageReadParam irp = new ImageReadParam();
 
             // subsample by 2 on both dimensions
@@ -105,7 +105,7 @@ public class HDF4TeraScanTest extends TestCase {
             final ImageLayout l = new ImageLayout();
             l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(64).setTileWidth(64);
 
-            pbjImageRead = new ParameterBlockJAI("ImageRead");
+            pbjImageRead = new ParameterBlockImageN("ImageRead");
             pbjImageRead.setParameter("Input", file);
             pbjImageRead.setParameter("readParam", irp);
 

--- a/plugin/unidata-netcdf/netcdfconverters/src/main/java/it/geosolutions/imageio/plugins/netcdf/HOPSConverter.java
+++ b/plugin/unidata-netcdf/netcdfconverters/src/main/java/it/geosolutions/imageio/plugins/netcdf/HOPSConverter.java
@@ -27,7 +27,7 @@ import java.util.GregorianCalendar;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.RasterFactory;
 import org.eclipse.imagen.iterator.RandomIterFactory;
 import org.eclipse.imagen.iterator.WritableRandomIter;
@@ -330,7 +330,7 @@ public class HOPSConverter{
             // something bad happened
             if (LOGGER.isLoggable(Level.INFO))
                 LOGGER.log(Level.INFO, e.getLocalizedMessage(), e);
-            JAI.getDefaultInstance().getTileCache().flush();
+            ImageN.getDefaultInstance().getTileCache().flush();
         }
     }
 

--- a/plugin/unidata-netcdf/netcdfconverters/src/main/java/it/geosolutions/imageio/plugins/netcdf/MercatorOceanConverter.java
+++ b/plugin/unidata-netcdf/netcdfconverters/src/main/java/it/geosolutions/imageio/plugins/netcdf/MercatorOceanConverter.java
@@ -32,7 +32,7 @@ import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.RasterFactory;
 import org.eclipse.imagen.iterator.RandomIterFactory;
 import org.eclipse.imagen.iterator.WritableRandomIter;
@@ -400,7 +400,7 @@ public class MercatorOceanConverter {
             // something bad happened
             if (LOGGER.isLoggable(Level.INFO))
                 LOGGER.log(Level.INFO, e.getLocalizedMessage(), e);
-            JAI.getDefaultInstance().getTileCache().flush();
+            ImageN.getDefaultInstance().getTileCache().flush();
         }
 
     }

--- a/plugin/unidata-netcdf/netcdfconverters/src/main/java/it/geosolutions/imageio/plugins/netcdf/NCOMConverter.java
+++ b/plugin/unidata-netcdf/netcdfconverters/src/main/java/it/geosolutions/imageio/plugins/netcdf/NCOMConverter.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Level;
 
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 
 import ucar.ma2.Array;
 import ucar.ma2.ArrayFloat;
@@ -287,7 +287,7 @@ public class NCOMConverter {
             // something bad happened
             if (NetCDFConverterUtilities.LOGGER.isLoggable(Level.INFO))
                 NetCDFConverterUtilities.LOGGER.log(Level.INFO, e.getLocalizedMessage(), e);
-            JAI.getDefaultInstance().getTileCache().flush();
+            ImageN.getDefaultInstance().getTileCache().flush();
         }
     }
 

--- a/plugin/unidata-netcdf/netcdfconverters/src/main/java/it/geosolutions/imageio/plugins/netcdf/SWANConverter.java
+++ b/plugin/unidata-netcdf/netcdfconverters/src/main/java/it/geosolutions/imageio/plugins/netcdf/SWANConverter.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 
 import ucar.ma2.Array;
 import ucar.ma2.ArrayFloat;
@@ -253,7 +253,7 @@ public class SWANConverter {
             // something bad happened
             if (NetCDFConverterUtilities.LOGGER.isLoggable(Level.INFO))
                 NetCDFConverterUtilities.LOGGER.log(Level.INFO, e.getLocalizedMessage(), e);
-            JAI.getDefaultInstance().getTileCache().flush();
+            ImageN.getDefaultInstance().getTileCache().flush();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <gdal.version>3.2.0</gdal.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <libdeflate.java.version>0.1.0-beta</libdeflate.java.version>
-    <imagen.version>0.4.0</imagen.version>
+    <imagen.version>0.9.0-SNAPSHOT</imagen.version>
     <surefire.jvm.args></surefire.jvm.args>
   </properties>
 


### PR DESCRIPTION
Key goal for ImageN 0.9.0-SNAPSHOT development:

Concurrent merge of jai-rename branches:

* https://github.com/eclipse-imagen/imagen/pull/115
* https://github.com/geosolutions-it/imageio-ext/pull/334
* https://github.com/geotools/geotools/pull/5364
* https://github.com/mapfish/mapfish-print-v2/pull/39
* https://github.com/GeoWebCache/geowebcache/pull/1434
* https://github.com/geoserver/geoserver/pull/8821

Reviewers: Note complete ImageN integration test, or check out everything and build locally.