### PR TITLE
Update GDAL version from 3.2.0 to 3.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <test.maxHeapSize>512M</test.maxHeapSize>
     <kakadu.version>5.2.6</kakadu.version>
     <java.awt.headless>true</java.awt.headless>
-    <gdal.version>3.2.0</gdal.version>
+    <gdal.version>3.11.0</gdal.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <libdeflate.java.version>0.1.0-beta</libdeflate.java.version>
     <imagen.version>0.9.2-SNAPSHOT</imagen.version>


### PR DESCRIPTION
While I am testing locally with gdal-3.11.5, I can only find gdal-3.11.0 when searching public maven repository.

* https://github.com/geosolutions-it/imageio-ext/issues/347