### PR TITLE
Update imagen.version to 0.9.3-SNAPSHOT

### DIFF
--- a/library/utilities/pom.xml
+++ b/library/utilities/pom.xml
@@ -15,11 +15,11 @@
   <dependencies>
     <dependency>
       <groupId>org.eclipse.imagen</groupId>
-      <artifactId>imageread</artifactId>
+      <artifactId>imagen-imageread</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.imagen</groupId>
-      <artifactId>rendered-image-browser</artifactId>
+      <artifactId>imagen-rendered-image-browser</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/plugin/png/pom.xml
+++ b/plugin/png/pom.xml
@@ -52,12 +52,12 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.imagen</groupId>
-      <artifactId>bandmerge</artifactId>
+      <artifactId>imagen-bandmerge</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.imagen</groupId>
-      <artifactId>mosaic</artifactId>
+      <artifactId>imagen-mosaic</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <gdal.version>3.2.0</gdal.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <libdeflate.java.version>0.1.0-beta</libdeflate.java.version>
-    <imagen.version>0.9.2</imagen.version>
+    <imagen.version>0.9.3-SNAPSHOT</imagen.version>
     <surefire.jvm.args></surefire.jvm.args>
     <failsafe.forkcount>1C</failsafe.forkcount>
     <pom.fmt.action>sort</pom.fmt.action>

--- a/pom.xml
+++ b/pom.xml
@@ -113,23 +113,23 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.imagen</groupId>
-        <artifactId>imageread</artifactId>
+        <artifactId>imagen-imageread</artifactId>
         <version>${imagen.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.imagen</groupId>
-        <artifactId>rendered-image-browser</artifactId>
+        <artifactId>imagen-rendered-image-browser</artifactId>
         <version>${imagen.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.imagen</groupId>
-        <artifactId>bandmerge</artifactId>
+        <artifactId>imagen-bandmerge</artifactId>
         <version>${imagen.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.imagen</groupId>
-        <artifactId>mosaic</artifactId>
+        <artifactId>imagen-mosaic</artifactId>
         <version>${imagen.version}</version>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
Track ImageN `0.9.3-SNAPSHOT` during development cycle


This PR needs to be merged prior to the following:

* https://github.com/eclipse-imagen/imagen/pull/160
* https://github.com/geosolutions-it/imageio-ext/pull/495
* https://github.com/geosolutions-it/imageio-ext/pull/493
* https://github.com/geosolutions-it/imageio-ext/pull/495
* https://github.com/geotools/geotools/pull/5820
* https://github.com/GeoWebCache/geowebcache/pull/1568
* https://github.com/mapfish/mapfish-print-v2/pull/112
* https://github.com/geoserver/geoserver/pull/9792

