### PR TITLE
Avoid double build in 'validate formatting' and 'build and test' stages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,4 +48,4 @@ jobs:
         sudo mv /usr/lib/jni/libgdalalljni.so /usr/lib
 
     - name: Build and Test
-      run: mvn -U clean install -T1C -Dall -Djava.awt.headless=true -DskipTests=false -ntp -fae
+      run: mvn -U test install -T1C -Dall -Djava.awt.headless=true -DskipTests=false -ntp -fae


### PR DESCRIPTION
See https://github.com/geosolutions-it/imageio-ext/issues/496

1. Validate source code and pom formatting:  
   Is compiling and installing
2. Build and Test:  
   Is also compiling and installing due to use of clean

This PR changes to `test install` once GDAL is available, no longer forcing rebuild 