### PR TITLE
Pin test container images, floating tags break the build when upstream changes

### DIFF
--- a/plugin/cog/cog-reader/src/test/java/it/geosolutions/imageioimpl/plugins/cog/http/CogImageReaderHttpIT.java
+++ b/plugin/cog/cog-reader/src/test/java/it/geosolutions/imageioimpl/plugins/cog/http/CogImageReaderHttpIT.java
@@ -73,7 +73,7 @@ public class CogImageReaderHttpIT extends BaseCogImageReaderTest {
         Path landTopoCog1024 = testData.landTopoCog1024();
         String fileName = landTopoCog1024.getFileName().toString();
 
-        nginx = new NginxContainer("nginx:latest")
+        nginx = new NginxContainer("nginx:1.30.4")
                 .withCopyToContainer(MountableFile.forHostPath(landTopoCog1024), "/usr/share/nginx/html/" + fileName);
         nginx.start();
 

--- a/plugin/cog/cog-reader/src/test/java/it/geosolutions/imageioimpl/plugins/cog/s3/CogImageReaderS3LocalStackIT.java
+++ b/plugin/cog/cog-reader/src/test/java/it/geosolutions/imageioimpl/plugins/cog/s3/CogImageReaderS3LocalStackIT.java
@@ -68,7 +68,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
  */
 public class CogImageReaderS3LocalStackIT extends BaseCogImageReaderTest {
 
-    private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse("localstack/localstack:s3-latest");
+    private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse("localstack/localstack:4.14.0");
 
     private static final String BUCKET_NAME = "test-bucket";
 

--- a/plugin/cog/cog-reader/src/test/java/it/geosolutions/imageioimpl/plugins/cog/s3/CogImageReaderS3MinioIT.java
+++ b/plugin/cog/cog-reader/src/test/java/it/geosolutions/imageioimpl/plugins/cog/s3/CogImageReaderS3MinioIT.java
@@ -75,7 +75,7 @@ public class CogImageReaderS3MinioIT extends BaseCogImageReaderTest {
     @ClassRule
     public static CogTestData testData = new CogTestData();
 
-    static MinIOContainer container = new MinIOContainer("minio/minio:latest");
+    static MinIOContainer container = new MinIOContainer("minio/minio:RELEASE.2025-09-07T16-13-09Z");
 
     private static S3Client s3Client;
 


### PR DESCRIPTION
This is a fix for the COG-S3 tests failing, and pinning other tests to a specific version to avoid a similar problem.
Now, this is just a stopgap measure:
* Localstack has gone commercial on us
* Minio did too

In the future, ee should probably rewrite the S3 tests to use https://github.com/adobe/S3Mock instead, that's alive and well.